### PR TITLE
Do not use liquibase in production

### DIFF
--- a/k8s/oncokb-public-local.yml
+++ b/k8s/oncokb-public-local.yml
@@ -20,7 +20,7 @@ spec:
           image: cbioportal/oncokb-public:0.0.alpha.23
           env:
             - name: SPRING_PROFILES_ACTIVE
-              value: prod
+              value: prod,no-liquibase
             - name: JAVA_OPTS
               value: '-Xmx1024m -Xms512m'
           envFrom:

--- a/k8s/oncokb-public-local.yml
+++ b/k8s/oncokb-public-local.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: oncokb-public
-          image: cbioportal/oncokb-public:0.0.alpha.23
+          image: cbioportal/oncokb-public:0.0.alpha.24
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod,no-liquibase

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
                             <image>adoptopenjdk:11-jre-hotspot</image>
                         </from>
                         <to>
-                            <image>cbioportal/oncokb-public:0.0.alpha.23</image>
+                            <image>cbioportal/oncokb-public:0.0.alpha.24</image>
                         </to>
                         <container>
                             <entrypoint>

--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   oncokb-app:
-    image: cbioportal/oncokb-public:0.0.alpha.23
+    image: cbioportal/oncokb-public:0.0.alpha.24
     environment:
       - _JAVA_OPTIONS=-Xmx512m -Xms256m
       - SPRING_PROFILES_ACTIVE=prod,swagger


### PR DESCRIPTION
Liquibase sometimes lock the database when there is an issue restarting the pod. This should be disabled cause you are not expecting to modify the DB schema in production