### PR TITLE
Remove logback-classic from thymeleaf

### DIFF
--- a/k8s/oncokb-public-local.yml
+++ b/k8s/oncokb-public-local.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: oncokb-public
-          image: cbioportal/oncokb-public:2.2.5
+          image: cbioportal/oncokb-public:2.2.6
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod,no-liquibase

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.mskcc.cbio.oncokb</groupId>
     <artifactId>public-website</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
     <packaging>jar</packaging>
     <name>OncoKB Public Website</name>
 
@@ -261,6 +261,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -602,7 +608,7 @@
                             <image>adoptopenjdk:11-jre-hotspot</image>
                         </from>
                         <to>
-                            <image>cbioportal/oncokb-public:2.2.5</image>
+                            <image>cbioportal/oncokb-public:2.2.6</image>
                         </to>
                         <container>
                             <entrypoint>

--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   oncokb-app:
-    image: cbioportal/oncokb-public:2.2.5
+    image: cbioportal/oncokb-public:2.2.6
     environment:
       - _JAVA_OPTIONS=-Xmx512m -Xms256m
       - SPRING_PROFILES_ACTIVE=prod,swagger


### PR DESCRIPTION
This solution is coming from https://stackoverflow.com/questions/30792268/loggerfactory-is-not-a-logback-loggercontext-but-logback-is-on-the-classpath

This fixes https://github.com/oncokb/oncokb/issues/1962