### PR TITLE
Exclude slf4j from jslack to avoid duplicate slf4j dependencies

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: '$NEXT_MINOR_VERSION'
-tag-template: '$NEXT_MINOR_VERSION'
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
 categories:
   - title: '🧬 Features'
     labels:
@@ -37,4 +37,4 @@ template: |
 
   ## 🕵️‍♀️ Full commit logs
 
-  - https://github.com/oncokb/oncokb-public/compare/$PREVIOUS_TAG...$NEXT_MINOR_VERSION
+  - https://github.com/oncokb/oncokb-public/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION

--- a/k8s/oncokb-public-local.yml
+++ b/k8s/oncokb-public-local.yml
@@ -4,11 +4,16 @@ metadata:
   name: oncokb-public
   namespace: default
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: oncokb-public
       version: 'v1'
+  strategy:
+    rollingUpdate:
+      maxSurge: 4
+      maxUnavailable: 2
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -17,7 +22,7 @@ spec:
     spec:
       containers:
         - name: oncokb-public
-          image: cbioportal/oncokb-public:2.3.0
+          image: cbioportal/oncokb-public:2.3.1
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod,no-liquibase

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.mskcc.cbio.oncokb</groupId>
     <artifactId>public-website</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <packaging>jar</packaging>
     <name>OncoKB Public Website</name>
 
@@ -79,7 +79,7 @@
         <frontend-maven-plugin.version>1.9.1</frontend-maven-plugin.version>
         <git-commit-id-plugin.version>4.0.0</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-        <jib-maven-plugin.version>2.0.0</jib-maven-plugin.version>
+        <jib-maven-plugin.version>2.1.0</jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
@@ -250,12 +250,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
-            <exclusions>
-              <exclusion>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-              </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -347,6 +341,12 @@
           <groupId>com.github.seratch</groupId>
           <artifactId>jslack</artifactId>
           <version>${jslack.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.jboss.slf4j</groupId>
+              <artifactId>slf4j-jboss-logging</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       <!-- jhipster-needle-maven-add-dependency -->
     </dependencies>
@@ -621,7 +621,7 @@
                             <image>adoptopenjdk:11-jre-hotspot</image>
                         </from>
                         <to>
-                            <image>cbioportal/oncokb-public:2.3.0</image>
+                            <image>cbioportal/oncokb-public:2.3.1</image>
                         </to>
                         <container>
                             <entrypoint>

--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   oncokb-app:
-    image: cbioportal/oncokb-public:2.3.0
+    image: cbioportal/oncokb-public:2.3.1
     environment:
       - _JAVA_OPTIONS=-Xmx512m -Xms256m
       - SPRING_PROFILES_ACTIVE=prod,swagger


### PR DESCRIPTION
Another attempt to address https://github.com/oncokb/oncokb/issues/1962