### PR TITLE
Publish sentry release after make a GitHub release

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,22 @@
+name: Sentrey Release 
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  createSentryRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create a Sentry.io release
+        uses: tclindner/sentry-releases-action@v1.0.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: memorial-sloan-kettering
+          SENTRY_PROJECT: oncokb-public-website
+        with:
+          tagName: ${{ github.ref }}
+          environment: production
+          releaseNamePrefix: oncokb-public-


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb/issues/2035