### PR TITLE
Update the permission of allCuratedGenes with txt/json extension

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/SecurityConfiguration.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/SecurityConfiguration.java
@@ -99,6 +99,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/v1/drugs/**").hasAnyAuthority(AuthoritiesConstants.PREMIUM_USER, AuthoritiesConstants.ADMIN)
 
             .antMatchers("/api/v1/utils/allCuratedGenes").permitAll()
+            .antMatchers("/api/v1/utils/allCuratedGenes.txt").permitAll()
+            .antMatchers("/api/v1/utils/allCuratedGenes.json").permitAll()
             .antMatchers("/api/v1/utils/cancerGeneList").permitAll()
             .antMatchers("/api/v1/utils/cancerGeneList.txt").permitAll()
             .antMatchers("/api/v1/utils/cancerGeneList.json").permitAll()


### PR DESCRIPTION
I forgot to allow access to txt/json version of the allCuratedGenes.
This fixes https://github.com/oncokb/oncokb-annotator/issues/59