### PR TITLE
Update token usage by cronjob instead of basing on actually API calls

### DIFF
--- a/.jhipster/TokenStats.json
+++ b/.jhipster/TokenStats.json
@@ -25,6 +25,13 @@
             "fieldValidateRules": [
                 "required"
             ]
+        },
+        {
+            "fieldName": "usageCount",
+            "fieldType": "Integer",
+            "fieldValidateRules": [
+                "required"
+            ]
         }
     ],
     "changelogDate": "20190826144658",

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -34,9 +34,7 @@
     "blueprints": [],
     "clientFramework": "react",
     "clientTheme": "none",
-    "appsFolders": [
-      "public-website"
-    ],
+    "appsFolders": ["public-website"],
     "directoryPath": "../",
     "dockerRepositoryName": "oncokb-public",
     "dockerPushCommand": "docker push",

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
@@ -35,6 +35,10 @@ public class TokenStats implements Serializable {
     @Column(name = "access_time", nullable = false)
     private Instant accessTime;
 
+    @NotNull
+    @Column(name = "usage_count", nullable = false)
+    private Integer usageCount;
+
     @ManyToOne
     @JsonIgnoreProperties("tokenStats")
     private Token token;
@@ -87,6 +91,19 @@ public class TokenStats implements Serializable {
         this.accessTime = accessTime;
     }
 
+    public Integer getUsageCount() {
+        return usageCount;
+    }
+
+    public TokenStats usageCount(Integer usageCount) {
+        this.usageCount = usageCount;
+        return this;
+    }
+
+    public void setUsageCount(Integer usageCount) {
+        this.usageCount = usageCount;
+    }
+
     public Token getToken() {
         return token;
     }
@@ -124,6 +141,7 @@ public class TokenStats implements Serializable {
             ", accessIp='" + getAccessIp() + "'" +
             ", resource='" + getResource() + "'" +
             ", accessTime='" + getAccessTime() + "'" +
+            ", usageCount=" + getUsageCount() +
             "}";
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/querydomain/UserTokenUsage.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/querydomain/UserTokenUsage.java
@@ -1,0 +1,11 @@
+package org.mskcc.cbio.oncokb.querydomain;
+
+import org.mskcc.cbio.oncokb.domain.Token;
+
+/**
+ * Created by Hongxin Zhang on 7/1/20.
+ */
+public interface UserTokenUsage {
+    Integer getCount();
+    Token getToken();
+}

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -2,6 +2,7 @@ package org.mskcc.cbio.oncokb.repository;
 
 import org.mskcc.cbio.oncokb.domain.TokenStats;
 
+import org.mskcc.cbio.oncokb.querydomain.UserTokenUsage;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,7 @@ import java.util.List;
 @Repository
 public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     List<TokenStats> findByAccessTimeBefore(Instant before);
+
+    @Query("select sum(tokenStats.usageCount) as count, tokenStats.token as token from TokenStats tokenStats group by tokenStats.token")
+    List<UserTokenUsage> countTokenUsageByToken();
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -17,6 +17,6 @@ import java.util.List;
 public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     List<TokenStats> findByAccessTimeBefore(Instant before);
 
-    @Query("select sum(tokenStats.usageCount) as count, tokenStats.token as token from TokenStats tokenStats group by tokenStats.token")
-    List<UserTokenUsage> countTokenUsageByToken();
+    @Query("select sum(tokenStats.usageCount) as count, tokenStats.token as token from TokenStats tokenStats where tokenStats.accessTime < ?1 group by tokenStats.token")
+    List<UserTokenUsage> countTokenUsageByToken(Instant before);
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
@@ -3,6 +3,7 @@ package org.mskcc.cbio.oncokb.service;
 import org.mskcc.cbio.oncokb.domain.TokenStats;
 import org.mskcc.cbio.oncokb.querydomain.UserTokenUsage;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -43,5 +44,5 @@ public interface TokenStatsService {
 
     void removeOldTokenStats();
 
-    List<UserTokenUsage> getUserTokenUsage();
+    List<UserTokenUsage> getUserTokenUsage(Instant before);
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
@@ -1,6 +1,7 @@
 package org.mskcc.cbio.oncokb.service;
 
 import org.mskcc.cbio.oncokb.domain.TokenStats;
+import org.mskcc.cbio.oncokb.querydomain.UserTokenUsage;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,4 +42,6 @@ public interface TokenStatsService {
     void delete(Long id);
 
     void removeOldTokenStats();
+
+    List<UserTokenUsage> getUserTokenUsage();
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
@@ -1,6 +1,7 @@
 package org.mskcc.cbio.oncokb.service.impl;
 
 import io.github.jhipster.config.JHipsterProperties;
+import org.mskcc.cbio.oncokb.querydomain.UserTokenUsage;
 import org.mskcc.cbio.oncokb.service.TokenStatsService;
 import org.mskcc.cbio.oncokb.domain.TokenStats;
 import org.mskcc.cbio.oncokb.repository.TokenStatsRepository;
@@ -92,5 +93,9 @@ public class TokenStatsServiceImpl implements TokenStatsService {
                 log.debug("Deleting token stats", tokenStat);
                 tokenStatsRepository.delete(tokenStat);
             });
+    }
+
+    public List<UserTokenUsage> getUserTokenUsage() {
+        return tokenStatsRepository.countTokenUsageByToken();
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
@@ -95,7 +95,7 @@ public class TokenStatsServiceImpl implements TokenStatsService {
             });
     }
 
-    public List<UserTokenUsage> getUserTokenUsage() {
-        return tokenStatsRepository.countTokenUsageByToken();
+    public List<UserTokenUsage> getUserTokenUsage(Instant before) {
+        return tokenStatsRepository.countTokenUsageByToken(before);
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/ApiProxy.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/ApiProxy.java
@@ -96,7 +96,6 @@ public class ApiProxy {
                 List<Token> tokenList = tokenProvider.getUserTokens(user.get());
                 int usageCount = getUsageCount(body, method);
                 tokenList.forEach(token -> {
-                    tokenService.increaseTokenUsage(token.getId(), usageCount);
                     // Check the current public website token usage
                     // Send email if the token usage beyonds the threshold
                     // This is not guaranteed to be triggered if the request is a post and total passes the cutoff
@@ -149,7 +148,6 @@ public class ApiProxy {
                 !tokenUsageCheckWhitelist.contains(user.get().getLogin())) {
                 List<Token> tokenList = tokenProvider.getUserTokens(user.get());
                 tokenList.forEach(token -> {
-                    tokenService.increaseTokenUsage(token.getId(), usageCount);
                     if (uuidOptional.isPresent() && uuidOptional.get().equals(token.getToken())) {
                         TokenStats tokenStats = new TokenStats();
                         tokenStats.setToken(token);
@@ -161,6 +159,7 @@ public class ApiProxy {
                             tokenStats.setAccessIp(ipAddress);
                         }
                         tokenStats.setAccessTime(Instant.now());
+                        tokenStats.setUsageCount(usageCount);
                         tokenStats.setResource(request.getMethod() + " " + request.getRequestURI());
                         tokenStatsService.save(tokenStats);
                     }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
@@ -133,7 +133,7 @@ public class CronJobController {
     @GetMapping(path = "/update-token-stats")
     public void updateTokenStats() {
         log.info("Started the cronjob to update token stats");
-        List<UserTokenUsage> tokenUsages = tokenStatsService.getUserTokenUsage();
+        List<UserTokenUsage> tokenUsages = tokenStatsService.getUserTokenUsage(Instant.now());
         tokenUsages.stream().forEach(tokenUsage -> {
             if (!tokenUsage.getToken().getCurrentUsage().equals(tokenUsage.getCount())) {
                 tokenUsage.getToken().setCurrentUsage(tokenUsage.getCount());

--- a/src/main/resources/config/liquibase/changelog/20190826144658_added_entity_TokenStats.xml
+++ b/src/main/resources/config/liquibase/changelog/20190826144658_added_entity_TokenStats.xml
@@ -25,6 +25,9 @@
             <column name="access_time" type="datetime">
                 <constraints nullable="false" />
             </column>
+            <column name="usage_count" type="integer">
+                <constraints nullable="false" />
+            </column>
             <column name="token_id" type="bigint">
                 <constraints nullable="true" />
             </column>
@@ -38,5 +41,26 @@
     </changeSet>
     <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
 
+    <!--
+        Load sample data generated with Faker.js
+        - This data can be easily edited using a CSV editor (or even MS Excel) and
+          is located in the 'src/main/resources/config/liquibase/fake-data' directory
+        - By default this data is applied when running with the JHipster 'dev' profile.
+          This can be customized by adding or removing 'faker' in the 'spring.liquibase.contexts'
+          Spring Boot configuration key.
+    -->
+    <changeSet id="20190826144658-1-data" author="jhipster" context="faker">
+        <loadData
+                  file="config/liquibase/fake-data/token_stats.csv"
+                  separator=";"
+                  tableName="token_stats">
+            <column name="id" type="numeric"/>
+            <column name="access_ip" type="string"/>
+            <column name="resource" type="string"/>
+            <column name="access_time" type="datetime"/>
+            <column name="usage_count" type="numeric"/>
+            <!-- jhipster-needle-liquibase-add-loadcolumn - JHipster (and/or extensions) can add load columns here, do not remove-->
+        </loadData>
+    </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/fake-data/token_stats.csv
+++ b/src/main/resources/config/liquibase/fake-data/token_stats.csv
@@ -1,0 +1,11 @@
+id;access_ip;resource;access_time;usage_count
+1;green Tasty Cotton Tuna;Agent digital;2019-08-25T22:33:05;24113
+2;yellow Cambridgeshire Pennsylvania;Kentucky;2019-08-25T15:03:02;25631
+3;transform bandwidth solid state;Central Pants Games;2019-08-26T08:30:15;80125
+4;Ergonomic;Manager;2019-08-26T00:14:24;29157
+5;backing up Refined Rubber Sausages Factors;deposit optical out-of-the-box;2019-08-25T16:18:12;6078
+6;white;magenta;2019-08-26T08:40:00;12805
+7;multi-byte;Trail Associate;2019-08-25T17:14:48;94909
+8;programming Fully-configurable;Home Loan Account distributed;2019-08-25T18:04:36;60964
+9;exuding;Indiana Practical Granite Chair;2019-08-25T16:27:08;98773
+10;Iowa PCI Tennessee;RAM Madagascar overriding;2019-08-25T23:59:58;98856


### PR DESCRIPTION
We should not update the token based on the api call, that will mess up with the cache.
This fixes https://github.com/oncokb/oncokb/issues/2095

This is related to https://github.com/oncokb/oncokb/issues/2110