### PR TITLE
Automatically publish docker image when a release is published

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,36 @@
+name: Build/Push docker image
+on:
+  release:
+    types: [published]
+jobs:
+  main:
+    if: github.repository == 'oncokb/oncokb-public'
+    name: Build and Push
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: 12.16.1
+      SPRING_OUTPUT_ANSI_ENABLED: DETECT
+      SPRING_JPA_SHOW_SQL: false
+      JHI_DISABLE_WEBPACK_LOGS: true
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.16.1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11.x'
+      - name: Install node.js packages
+        run: yarn install
+      - name: Package application with Jib
+        env:
+          DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          ./mvnw -ntp package -Pprod verify jib:dockerBuild \
+          -DskipTests \
+          -Djib.to.image="${REPOSITORY}:${TAG_NAME}" \
+          -Djib.to.auth.username=$DOCKER_USERNAME \
+          -Djib.to.auth.password=$DOCKER_PASSWORD

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -7,12 +7,13 @@ on:
 # Make too releases since frontend/backend are in the same repo but two different sentry projects
 jobs:
   createSentryRelease:
+    if: github.repository == 'oncokb/oncokb-public'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@master
       - name: Create a Sentry.io release in oncokb-public-website
-        uses: tclindner/sentry-releases-action@v1.0.0
+        uses: tclindner/sentry-releases-action@v1.2.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: memorial-sloan-kettering
@@ -22,7 +23,7 @@ jobs:
           environment: production
           releaseNamePrefix: oncokb-public-
       - name: Create a Sentry.io release in oncokb-public-website-backend
-        uses: tclindner/sentry-releases-action@v1.0.0
+        uses: tclindner/sentry-releases-action@v1.2.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: memorial-sloan-kettering


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2257
This is related to https://github.com/oncokb/oncokb/issues/1990