### PR TITLE
Show Tx/Dx/Px seperately on Home Page and Actionable Genes Page

### DIFF
--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -117,15 +117,62 @@ const EVIDENCE_TYPE = {
   BIOLOGICAL_EVIDENCE: 'Biological evidence',
 };
 
-export const LEVEL_BUTTON_DESCRIPTION = {
-  '1': EVIDENCE_TYPE.FDA_APPROVED,
-  '2': EVIDENCE_TYPE.STANDARD_CARE,
-  '3': EVIDENCE_TYPE.CLINICAL_EVIDENCE,
-  '4': EVIDENCE_TYPE.BIOLOGICAL_EVIDENCE,
-  R1: EVIDENCE_TYPE.STANDARD_CARE,
-  R2: EVIDENCE_TYPE.CLINICAL_EVIDENCE,
+export enum LEVEL_TYPES {
+  TX = 'Tx',
+  DX = 'Dx',
+  PX = 'Px',
+}
+
+export const LEVEL_TYPE_NAMES = {
+  [LEVEL_TYPES.TX]: 'Therapeutic',
+  [LEVEL_TYPES.DX]: 'Diagnostic',
+  [LEVEL_TYPES.PX]: 'Prognostic',
 };
-export const LEVELS = ['1', '2', '3', '4', 'R1', 'R2'];
+
+export enum LEVELS {
+  Dx1 = 'Dx1',
+  Dx2 = 'Dx2',
+  Dx3 = 'Dx3',
+  Px1 = 'Px1',
+  Px2 = 'Px2',
+  Px3 = 'Px3',
+  Tx1 = '1',
+  Tx2 = '2',
+  Tx3 = '3',
+  Tx4 = '4',
+  R1 = 'R1',
+  R2 = 'R2',
+}
+
+export const LEVEL_BUTTON_DESCRIPTION = {
+  [LEVELS.Tx1]: EVIDENCE_TYPE.FDA_APPROVED,
+  [LEVELS.Tx2]: EVIDENCE_TYPE.STANDARD_CARE,
+  [LEVELS.Tx3]: EVIDENCE_TYPE.CLINICAL_EVIDENCE,
+  [LEVELS.Tx4]: EVIDENCE_TYPE.BIOLOGICAL_EVIDENCE,
+  [LEVELS.R1]: EVIDENCE_TYPE.STANDARD_CARE,
+  [LEVELS.R2]: EVIDENCE_TYPE.CLINICAL_EVIDENCE,
+  [LEVELS.Dx1]: 'Dx1 description',
+  [LEVELS.Dx2]: 'Dx2 description',
+  [LEVELS.Dx3]: 'Dx3 description',
+  [LEVELS.Px1]: 'Px1 description',
+  [LEVELS.Px2]: 'Px2 description',
+  [LEVELS.Px3]: 'Px3 description',
+};
+
+export const LEVEL_CLASSIFICATION = {
+  [LEVELS.Dx1]: LEVEL_TYPES.DX,
+  [LEVELS.Dx2]: LEVEL_TYPES.DX,
+  [LEVELS.Dx3]: LEVEL_TYPES.DX,
+  [LEVELS.Px1]: LEVEL_TYPES.PX,
+  [LEVELS.Px2]: LEVEL_TYPES.PX,
+  [LEVELS.Px3]: LEVEL_TYPES.PX,
+  [LEVELS.Tx1]: LEVEL_TYPES.TX,
+  [LEVELS.Tx2]: LEVEL_TYPES.TX,
+  [LEVELS.Tx3]: LEVEL_TYPES.TX,
+  [LEVELS.Tx4]: LEVEL_TYPES.TX,
+  [LEVELS.R1]: LEVEL_TYPES.TX,
+  [LEVELS.R2]: LEVEL_TYPES.TX,
+};
 export const LEVEL_OF_EVIDENCE = [
   'LEVEL_1',
   'LEVEL_2',
@@ -133,6 +180,12 @@ export const LEVEL_OF_EVIDENCE = [
   'LEVEL_4',
   'LEVEL_R1',
   'LEVEL_R2',
+  'LEVEL_Dx1',
+  'LEVEL_Dx2',
+  'LEVEL_Dx3',
+  'LEVEL_Px1',
+  'LEVEL_Px2',
+  'LEVEL_Px3',
 ];
 export const ONCOGENICITY_CLASS_NAMES: { [oncogenic: string]: string } = {
   [ONCOGENICITY.NEUTRAL]: 'neutral',

--- a/src/main/webapp/app/pages/HomePage.tsx
+++ b/src/main/webapp/app/pages/HomePage.tsx
@@ -8,18 +8,29 @@ import {
   LevelNumber,
   TypeaheadSearchResp,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col, Button } from 'react-bootstrap';
 import oncokbImg from 'content/images/oncokb.png';
 import { HomePageNumber } from 'app/components/HomePageNumber';
 import pluralize from 'pluralize';
-import { LEVEL_BUTTON_DESCRIPTION, PAGE_ROUTE } from 'app/config/constants';
+import {
+  LEVELS,
+  LEVEL_BUTTON_DESCRIPTION,
+  LEVEL_CLASSIFICATION,
+  LEVEL_TYPES,
+  LEVEL_TYPE_NAMES,
+  PAGE_ROUTE,
+} from 'app/config/constants';
 import { LevelButton } from 'app/components/levelButton/LevelButton';
-import { levelOfEvidence2Level } from 'app/shared/utils/Utils';
+import {
+  getShowingLevelNumber,
+  levelOfEvidence2Level,
+} from 'app/shared/utils/Utils';
 import { RouterStore } from 'mobx-react-router';
 import { CitationText } from 'app/components/CitationText';
 import _ from 'lodash';
 import AppStore from 'app/store/AppStore';
 import OncoKBSearch from 'app/components/oncokbSearch/OncoKBSearch';
+import autobind from 'autobind-decorator';
 
 interface IHomeProps {
   content: string;
@@ -36,46 +47,43 @@ export type ExtendedTypeaheadSearchResp = TypeaheadSearchResp & {
 @observer
 class HomePage extends React.Component<IHomeProps> {
   @observable keyword = '';
+  @observable levelTypeSelected = LEVEL_TYPES.TX;
+  private LevelGadgets = this.generateLevelGadgets();
 
-  private levelGadgets: {
-    title?: string;
-    description: string;
-    level: string;
-    linkoutLevel: string;
-    combinedLevels: string[];
-  }[] = [
-    {
-      level: '1',
-      description: LEVEL_BUTTON_DESCRIPTION['1'],
-      linkoutLevel: '1',
-      combinedLevels: ['1'],
-    },
-    {
-      level: '2',
-      description: LEVEL_BUTTON_DESCRIPTION['2'],
-      linkoutLevel: '2',
-      combinedLevels: ['2'],
-    },
-    {
-      level: '3',
-      description: LEVEL_BUTTON_DESCRIPTION['3'],
-      linkoutLevel: '3',
-      combinedLevels: ['3'],
-    },
-    {
-      level: '4',
-      description: LEVEL_BUTTON_DESCRIPTION['4'],
-      linkoutLevel: '4',
-      combinedLevels: ['4'],
-    },
-    {
-      level: 'R1',
-      description: 'Resistance',
-      title: 'Level R1/R2',
-      linkoutLevel: 'R1,R2',
-      combinedLevels: ['R1', 'R2'],
-    },
-  ];
+  generateLevelGadgets() {
+    const levelGadgets: {
+      title?: string;
+      description: string;
+      level: string;
+      linkoutLevel: string;
+      combinedLevels: string[];
+    }[] = [];
+    for (const level in LEVELS) {
+      if (LEVELS[level]) {
+        switch (level) {
+          case LEVELS.R1:
+            levelGadgets.push({
+              level: LEVELS.R1,
+              description: 'Resistance',
+              title: `Level ${LEVELS.R1}/${LEVELS.R2}`,
+              linkoutLevel: `${LEVELS.R1},${LEVELS.R2}`,
+              combinedLevels: [LEVELS.R1, LEVELS.R2],
+            });
+            break;
+          case LEVELS.R2:
+            break;
+          default:
+            levelGadgets.push({
+              level: LEVELS[level],
+              description: LEVEL_BUTTON_DESCRIPTION[LEVELS[level]],
+              linkoutLevel: LEVELS[level],
+              combinedLevels: [LEVELS[level]],
+            });
+        }
+      }
+    }
+    return levelGadgets;
+  }
 
   readonly levelNumbers = remoteData<{ [level: string]: LevelNumber }>({
     await: () => [],
@@ -114,7 +122,30 @@ class HomePage extends React.Component<IHomeProps> {
     ).length;
   }
 
+  @autobind
+  @action
+  handleLevelTypeButton(type: any) {
+    this.levelTypeSelected = type;
+  }
+
   public render() {
+    const levelTypeButtons = [];
+    for (const key in LEVEL_TYPES) {
+      if (LEVEL_TYPES[key]) {
+        levelTypeButtons.push(
+          <Button
+            className="mr-5"
+            variant={
+              this.levelTypeSelected === LEVEL_TYPES[key] ? 'primary' : 'light'
+            }
+            size="sm"
+            onClick={() => this.handleLevelTypeButton(LEVEL_TYPES[key])}
+          >
+            {LEVEL_TYPE_NAMES[LEVEL_TYPES[key]]} Levels
+          </Button>
+        );
+      }
+    }
     return (
       <div className="home">
         <Row className="mb-5">
@@ -178,20 +209,41 @@ class HomePage extends React.Component<IHomeProps> {
             <OncoKBSearch />
           </Col>
         </Row>
-        <Row className="mb-5">
+        <Row className="mb-2">
+          <div className="mx-auto">{levelTypeButtons}</div>
+        </Row>
+        <Row className="mb-5 d-flex d-flex justify-content-between">
           <Col xs={0} lg={1}></Col>
-          {this.levelGadgets.map(levelGadget => (
-            <Col xs={12} sm={6} lg={2} key={levelGadget.level} className="px-0">
-              <LevelButton
-                level={levelGadget.level}
-                numOfGenes={this.getLevelNumber(levelGadget.combinedLevels)}
-                description={levelGadget.description}
-                title={levelGadget.title}
-                className="mb-2"
-                href={`/actionableGenes#levels=${levelGadget.linkoutLevel}`}
-              />
-            </Col>
-          ))}
+          {this.LevelGadgets.map(
+            levelGadget =>
+              ((this.levelTypeSelected === LEVEL_TYPES.DX &&
+                LEVEL_CLASSIFICATION[levelGadget.level] === LEVEL_TYPES.DX) ||
+                (this.levelTypeSelected === LEVEL_TYPES.PX &&
+                  LEVEL_CLASSIFICATION[levelGadget.level] === LEVEL_TYPES.PX) ||
+                (this.levelTypeSelected === LEVEL_TYPES.TX &&
+                  LEVEL_CLASSIFICATION[levelGadget.level] ===
+                    LEVEL_TYPES.TX)) && (
+                <Col
+                  xs={12}
+                  sm={6}
+                  lg={2}
+                  key={levelGadget.level}
+                  className="px-0"
+                >
+                  <LevelButton
+                    level={getShowingLevelNumber(
+                      this.levelTypeSelected,
+                      levelGadget.level
+                    )}
+                    numOfGenes={this.getLevelNumber(levelGadget.combinedLevels)}
+                    description={levelGadget.description}
+                    title={levelGadget.title}
+                    className="mb-2"
+                    href={`/actionableGenes#levels=${levelGadget.linkoutLevel}`}
+                  />
+                </Col>
+              )
+          )}
           <Col xs={0} lg={1}></Col>
         </Row>
         <Row className="mb-3">

--- a/src/main/webapp/app/pages/actionableGenesPage/LevelSelectionRow.tsx
+++ b/src/main/webapp/app/pages/actionableGenesPage/LevelSelectionRow.tsx
@@ -1,0 +1,114 @@
+import { LevelButton } from 'app/components/levelButton/LevelButton';
+import {
+  COMPONENT_PADDING,
+  LEVELS,
+  LEVEL_BUTTON_DESCRIPTION,
+  LEVEL_CLASSIFICATION,
+  LEVEL_TYPES,
+  LEVEL_TYPE_NAMES,
+} from 'app/config/constants';
+import React from 'react';
+import { Button, Col, Collapse, Row } from 'react-bootstrap';
+import classnames from 'classnames';
+import { getShowingLevelNumber } from 'app/shared/utils/Utils';
+
+type LevelSelectionRowProps = {
+  levelType: LEVEL_TYPES;
+  collapseStatus: { [levelType: string]: boolean };
+  levelNumbers: { [level: string]: number };
+  levelSelected: { [level: string]: boolean };
+  updateCollapseStatus: (levelType: LEVEL_TYPES) => void;
+  updateLevelSelection: (level: string) => void;
+};
+
+export const LevelSelectionRow: React.FunctionComponent<LevelSelectionRowProps> = props => {
+  const levelSelections = [];
+  for (const level in LEVELS) {
+    if (LEVELS[level]) {
+      levelSelections.push(
+        LEVEL_CLASSIFICATION[LEVELS[level]] ===
+          LEVEL_TYPES[props.levelType] && (
+          <Col
+            className={classnames(...COMPONENT_PADDING)}
+            lg={LEVEL_CLASSIFICATION[LEVELS[level]] === LEVEL_TYPES.TX ? 2 : 4}
+            xs={LEVEL_CLASSIFICATION[LEVELS[level]] === LEVEL_TYPES.TX ? 6 : 4}
+            key={LEVELS[level]}
+          >
+            <LevelButton
+              level={getShowingLevelNumber(
+                LEVEL_CLASSIFICATION[LEVELS[level]],
+                LEVELS[level]
+              )}
+              numOfGenes={props.levelNumbers[LEVELS[level]]}
+              description={LEVEL_BUTTON_DESCRIPTION[LEVELS[level]]}
+              active={props.levelSelected[LEVELS[level]]}
+              className="mb-2"
+              disabled={props.levelNumbers[LEVELS[level]] === 0}
+              onClick={() => props.updateLevelSelection(LEVELS[level])}
+            />
+          </Col>
+        )
+      );
+    }
+  }
+  return (
+    <>
+      <Row
+        style={{ paddingLeft: '1rem', paddingRight: '1rem' }}
+        className={'mb-2'}
+      >
+        <Button
+          style={{
+            backgroundColor: 'white',
+            border: 0,
+            textAlign: 'left',
+            paddingLeft: 0,
+            boxShadow: 'none',
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+          }}
+          variant="light"
+          onClick={() => {
+            props.updateCollapseStatus(props.levelType);
+          }}
+          block
+        >
+          <div style={{ flexGrow: 0, marginRight: '0.5em' }}>
+            {props.collapseStatus[props.levelType] ? (
+              <i className="fa fa-minus"></i>
+            ) : (
+              <i className="fa fa-plus"></i>
+            )}
+            {props.collapseStatus[props.levelType] ? (
+              <span>
+                {' '}
+                Click to hide {LEVEL_TYPE_NAMES[props.levelType]} Levels
+              </span>
+            ) : (
+              <span>
+                {' '}
+                Click to show {LEVEL_TYPE_NAMES[props.levelType]} Levels
+              </span>
+            )}
+          </div>
+          <div
+            style={{
+              flexGrow: 1,
+              height: '0.5px',
+              backgroundColor: 'rgba(0, 0, 0, 0.1)',
+            }}
+          ></div>
+        </Button>
+      </Row>
+      <Collapse in={props.collapseStatus[props.levelType]}>
+        <Row
+          style={{ paddingLeft: '0.5rem', paddingRight: '0.5rem' }}
+          className={'mb-2'}
+        >
+          {levelSelections}
+        </Row>
+      </Collapse>
+    </>
+  );
+};

--- a/src/main/webapp/app/routes/routes.tsx
+++ b/src/main/webapp/app/routes/routes.tsx
@@ -12,7 +12,7 @@ import AuthenticationStore from 'app/store/AuthenticationStore';
 import { TermsPage } from 'app/pages/TermsPage';
 import { TeamPage } from 'app/pages/teamPage/TeamPage';
 import CancerGenesPage from 'app/pages/CancerGenesPage';
-import ActionableGenesPage from 'app/pages/ActionableGenesPage';
+import ActionableGenesPage from 'app/pages/actionableGenesPage/ActionableGenesPage';
 import { RouterStore } from 'mobx-react-router';
 import GenePage from 'app/pages/genePage/GenePage';
 import AlterationPage from 'app/pages/alterationPage/AlterationPage';

--- a/src/main/webapp/app/shared/utils/Utils.tsx
+++ b/src/main/webapp/app/shared/utils/Utils.tsx
@@ -15,6 +15,7 @@ import {
   ONCOGENICITY_CLASS_NAMES,
   PAGE_ROUTE,
   TABLE_COLUMN_KEY,
+  LEVEL_TYPES,
 } from 'app/config/constants';
 import classnames from 'classnames';
 import {
@@ -443,3 +444,7 @@ export const scrollWidthOffsetInNews = (el?: any) => {
   const yOffset = -80;
   window.scrollTo({ top: yCoordinate + yOffset, behavior: 'smooth' });
 };
+
+export function getShowingLevelNumber(levelType: string, level: string) {
+  return levelType === LEVEL_TYPES.TX ? level : level.substring(2);
+}


### PR DESCRIPTION
This implements 

- https://github.com/oncokb/oncokb/issues/2081
- https://github.com/oncokb/oncokb/issues/2082

But the OncoKB-style-0.2.0-alpha.5 looks like still doesn't have icons for Dx/Px. It only has level colors for Dx/Px.

Below is the demo:
![chrome-capture](https://user-images.githubusercontent.com/32425638/100312313-9c9bc500-2f77-11eb-9cd4-98ab90045cbe.gif)
