### PR TITLE
Show level column first in the gene/variant page tables

### DIFF
--- a/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
@@ -172,9 +172,6 @@ export default class AnnotationPage extends React.Component<IAnnotationPage> {
         ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.ALTERATIONS),
       },
       {
-        ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.DRUGS),
-      },
-      {
         ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.EVIDENCE_CANCER_TYPE),
         Cell: (props: { original: any }) => {
           return (
@@ -191,6 +188,9 @@ export default class AnnotationPage extends React.Component<IAnnotationPage> {
             </Button>
           );
         },
+      },
+      {
+        ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.DRUGS),
       },
       {
         ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.CITATIONS),

--- a/src/main/webapp/app/pages/genePage/GenePage.tsx
+++ b/src/main/webapp/app/pages/genePage/GenePage.tsx
@@ -257,6 +257,10 @@ export default class GenePage extends React.Component<GenePageProps> {
   get clinicalTableColumns(): SearchColumn<ClinicalVariant>[] {
     return [
       {
+        ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.LEVEL),
+        accessor: 'level',
+      },
+      {
         ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.ALTERATION),
         accessor: 'variant',
         onFilter: (data: ClinicalVariant, keyword) =>
@@ -313,10 +317,6 @@ export default class GenePage extends React.Component<GenePageProps> {
             </WithSeparator>
           );
         },
-      },
-      {
-        ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.LEVEL),
-        accessor: 'level',
       },
       {
         ...getDefaultColumnDefinition(TABLE_COLUMN_KEY.CITATIONS),


### PR DESCRIPTION
This implemented 

- https://github.com/oncokb/oncokb/issues/2223 item 1

Gene Page:
![image](https://user-images.githubusercontent.com/32425638/101381032-dc1db780-387b-11eb-9bbe-2f9b27343dc0.png)

Variant Page:
![image](https://user-images.githubusercontent.com/32425638/101312924-a399c180-381a-11eb-97b3-09dbca7bc42f.png)
