### PR TITLE
Show Tx/Dx/Px seperately on Home Page and Actionable Genes Page - Stage 2

### DIFF
--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -151,12 +151,12 @@ export const LEVEL_BUTTON_DESCRIPTION = {
   [LEVELS.Tx4]: EVIDENCE_TYPE.BIOLOGICAL_EVIDENCE,
   [LEVELS.R1]: EVIDENCE_TYPE.STANDARD_CARE,
   [LEVELS.R2]: EVIDENCE_TYPE.CLINICAL_EVIDENCE,
-  [LEVELS.Dx1]: 'Dx1 description',
-  [LEVELS.Dx2]: 'Dx2 description',
-  [LEVELS.Dx3]: 'Dx3 description',
-  [LEVELS.Px1]: 'Px1 description',
-  [LEVELS.Px2]: 'Px2 description',
-  [LEVELS.Px3]: 'Px3 description',
+  [LEVELS.Dx1]: 'Required for diagnosis',
+  [LEVELS.Dx2]: 'Supports diagnosis',
+  [LEVELS.Dx3]: 'Investigative diagnosis',
+  [LEVELS.Px1]: 'Guideline-recognized with well-powered data',
+  [LEVELS.Px2]: 'Guideline-recognized with limited data',
+  [LEVELS.Px3]: 'Investigational',
 };
 
 export const LEVEL_CLASSIFICATION = {

--- a/src/main/webapp/app/pages/HomePage.tsx
+++ b/src/main/webapp/app/pages/HomePage.tsx
@@ -21,10 +21,7 @@ import {
   PAGE_ROUTE,
 } from 'app/config/constants';
 import { LevelButton } from 'app/components/levelButton/LevelButton';
-import {
-  getShowingLevelNumber,
-  levelOfEvidence2Level,
-} from 'app/shared/utils/Utils';
+import { levelOfEvidence2Level } from 'app/shared/utils/Utils';
 import { RouterStore } from 'mobx-react-router';
 import { CitationText } from 'app/components/CitationText';
 import _ from 'lodash';
@@ -226,15 +223,12 @@ class HomePage extends React.Component<IHomeProps> {
                 <Col
                   xs={12}
                   sm={6}
-                  lg={2}
+                  lg={this.levelTypeSelected === LEVEL_TYPES.TX ? 2 : 3}
                   key={levelGadget.level}
                   className="px-0"
                 >
                   <LevelButton
-                    level={getShowingLevelNumber(
-                      this.levelTypeSelected,
-                      levelGadget.level
-                    )}
+                    level={levelGadget.level}
                     numOfGenes={this.getLevelNumber(levelGadget.combinedLevels)}
                     description={levelGadget.description}
                     title={levelGadget.title}

--- a/src/main/webapp/app/pages/actionableGenesPage/ActionableGenesPage.tsx
+++ b/src/main/webapp/app/pages/actionableGenesPage/ActionableGenesPage.tsx
@@ -23,7 +23,6 @@ import {
   getCancerTypeNameFromOncoTreeType,
   getDefaultColumnDefinition,
   getDrugNameFromTreatment,
-  getShowingLevelNumber,
   getTreatmentNameFromEvidence,
   levelOfEvidence2Level,
 } from 'app/shared/utils/Utils';
@@ -591,10 +590,7 @@ export default class ActionableGenesPage extends React.Component<
                   key={LEVELS[level]}
                 >
                   <LevelButton
-                    level={getShowingLevelNumber(
-                      LEVEL_CLASSIFICATION[LEVELS[level]],
-                      LEVELS[level]
-                    )}
+                    level={LEVELS[level]}
                     numOfGenes={this.levelNumbers[LEVELS[level]]}
                     description={LEVEL_BUTTON_DESCRIPTION[LEVELS[level]]}
                     active={this.levelSelected[LEVELS[level]]}

--- a/src/main/webapp/app/pages/actionableGenesPage/LevelSelectionRow.tsx
+++ b/src/main/webapp/app/pages/actionableGenesPage/LevelSelectionRow.tsx
@@ -10,7 +10,6 @@ import {
 import React from 'react';
 import { Button, Col, Collapse, Row } from 'react-bootstrap';
 import classnames from 'classnames';
-import { getShowingLevelNumber } from 'app/shared/utils/Utils';
 
 type LevelSelectionRowProps = {
   levelType: LEVEL_TYPES;
@@ -35,10 +34,7 @@ export const LevelSelectionRow: React.FunctionComponent<LevelSelectionRowProps> 
             key={LEVELS[level]}
           >
             <LevelButton
-              level={getShowingLevelNumber(
-                LEVEL_CLASSIFICATION[LEVELS[level]],
-                LEVELS[level]
-              )}
+              level={LEVELS[level]}
               numOfGenes={props.levelNumbers[LEVELS[level]]}
               description={LEVEL_BUTTON_DESCRIPTION[LEVELS[level]]}
               active={props.levelSelected[LEVELS[level]]}

--- a/src/main/webapp/app/shared/utils/Utils.tsx
+++ b/src/main/webapp/app/shared/utils/Utils.tsx
@@ -444,7 +444,3 @@ export const scrollWidthOffsetInNews = (el?: any) => {
   const yOffset = -80;
   window.scrollTo({ top: yCoordinate + yOffset, behavior: 'smooth' });
 };
-
-export function getShowingLevelNumber(levelType: string, level: string) {
-  return levelType === LEVEL_TYPES.TX ? level : level.substring(2);
-}


### PR DESCRIPTION
This implemented https://github.com/oncokb/oncokb/issues/2081

Need to be solved: 

- [ ] Child component `LevelSelectionRow` status update issue on Actionable Genes Page.

Mockup:

- Home Page

![chrome-capture](https://user-images.githubusercontent.com/32425638/101513605-fd48db80-3941-11eb-8c7c-dd234e2c8600.gif)

- Actionable Gene Page

![image](https://user-images.githubusercontent.com/32425638/101513630-05a11680-3942-11eb-879b-a18a5df50acb.png)
