### PR TITLE
Only execute recaptcha when it's rendered

### DIFF
--- a/src/main/webapp/app/App.tsx
+++ b/src/main/webapp/app/App.tsx
@@ -73,6 +73,7 @@ class App extends React.Component {
             sitekey={RECAPTCHA_SITE_KEY}
             onVerify={this.onExecuteChange}
             onRender={() => {
+              this.stores.windowStore.recaptchaRendered = true;
               if (
                 !this.stores.authenticationStore.isUserAuthenticated &&
                 this.stores.routing.location.pathname !== PAGE_ROUTE.HOME

--- a/src/main/webapp/app/store/WindowStore.ts
+++ b/src/main/webapp/app/store/WindowStore.ts
@@ -13,6 +13,7 @@ class WindowStore {
   @observable size: IWindowSize;
   @observable recaptchaVerified: boolean;
   public recaptchaRef: any;
+  public recaptchaRendered = false;
   private handleWindowResize = _.debounce(this.setWindowSize, 200);
   private windowObj: any;
 
@@ -34,7 +35,7 @@ class WindowStore {
 
   @action
   private executeRecaptcha() {
-    if (this.recaptchaRef) {
+    if (this.recaptchaRef && this.recaptchaRendered) {
       this.recaptchaRef.current.execute();
     }
   }


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2389
I can reproduce the issue when I block the recaptcha.net
It could just be the recaptcha rendering is slow. In either situation, we should only validate recaptcha when it's rendered.