### PR TITLE
Do not show company info in the license explanation if the section is hidden through url

### DIFF
--- a/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
+++ b/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
@@ -211,10 +211,15 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
           </p>
           <p>
             <b>Please complete the form below to create your OncoKB account.</b>{' '}
-            If your company already has a license, you can skip certain fields
-            and we will grant you API access shortly. Otherwise, we will contact
-            you with license terms. You can also reach out to{' '}
-            <LicenseInquireLink /> for more information.
+            {this.props.visibleSections?.includes(FormSection.COMPANY) ? (
+              <span>
+                If your company already has a license, you can skip certain
+                fields and we will grant you API access shortly. Otherwise, we
+                will contact you with license terms.
+              </span>
+            ) : null}{' '}
+            You can also reach out to <LicenseInquireLink /> for more
+            information.
           </p>
         </>
       );
@@ -227,9 +232,15 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
           </p>
           <p>
             <b>Please complete the form below to create your OncoKB account.</b>{' '}
-            If your hospital already has a license, we will grant you API access
-            shortly. Otherwise, we will contact you with license terms. You can
-            also reach out to <LicenseInquireLink /> for more information.
+            {this.props.visibleSections?.includes(FormSection.COMPANY) ? (
+              <span>
+                If your hospital already has a license, we will grant you API
+                access shortly. Otherwise, we will contact you with license
+                terms.
+              </span>
+            ) : null}{' '}
+            You can also reach out to <LicenseInquireLink /> for more
+            information.
           </p>
         </>
       );
@@ -242,9 +253,15 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
           </p>
           <p>
             <b>Please complete the form below to create your OncoKB account.</b>{' '}
-            If your company already has a license, we will grant you API access
-            shortly. Otherwise, we will contact you with license terms. You can
-            also reach out to <LicenseInquireLink /> for more information.
+            {this.props.visibleSections?.includes(FormSection.COMPANY) ? (
+              <span>
+                If your company already has a license, we will grant you API
+                access shortly. Otherwise, we will contact you with license
+                terms.
+              </span>
+            ) : null}{' '}
+            You can also reach out to <LicenseInquireLink /> for more
+            information.
           </p>
         </>
       );


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2575