### PR TITLE
Fix the slack properties naming issue

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/application/SlackProperties.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/application/SlackProperties.java
@@ -5,9 +5,9 @@ package org.mskcc.cbio.oncokb.config.application;
  */
 public class SlackProperties {
     String userRegistrationWebhook;
-    String userRegistrationChannelID;
-    String slackBotOAuthToken;
-    String slackBaseURL;
+    String userRegistrationChannelId;
+    String slackBotOauthToken;
+    String slackBaseUrl;
 
     public String getUserRegistrationWebhook() {
         return userRegistrationWebhook;
@@ -17,27 +17,27 @@ public class SlackProperties {
         this.userRegistrationWebhook = userRegistrationWebhook;
     }
 
-    public String getUserRegistrationChannelID() {
-        return userRegistrationChannelID;
+    public String getUserRegistrationChannelId() {
+        return userRegistrationChannelId;
     }
 
-    public void setUserRegistrationChannelID(String userRegistrationChannelID) {
-        this.userRegistrationChannelID = userRegistrationChannelID;
+    public void setUserRegistrationChannelId(String userRegistrationChannelId) {
+        this.userRegistrationChannelId = userRegistrationChannelId;
     }
 
-    public String getSlackBotOAuthToken() {
-        return slackBotOAuthToken;
+    public String getSlackBotOauthToken() {
+        return slackBotOauthToken;
     }
 
-    public void setSlackBotOAuthToken(String slackBotOAuthToken) {
-        this.slackBotOAuthToken = slackBotOAuthToken;
+    public void setSlackBotOauthToken(String slackBotOauthToken) {
+        this.slackBotOauthToken = slackBotOauthToken;
     }
 
-    public String getSlackBaseURL() {
-        return slackBaseURL;
+    public String getSlackBaseUrl() {
+        return slackBaseUrl;
     }
 
-    public void setSlackBaseURL(String slackBaseURL) {
-        this.slackBaseURL = slackBaseURL;
+    public void setSlackBaseUrl(String slackBaseUrl) {
+        this.slackBaseUrl = slackBaseUrl;
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
@@ -329,8 +329,8 @@ public class MailService {
         context.setVariable("academicUsers", users);
         context.setVariable("daysAgo", daysAgo);
         context.setVariable(BASE_URL, jHipsterProperties.getMail().getBaseUrl());
-        context.setVariable("slackBaseUrl", applicationProperties.getSlack().getSlackBaseURL());
-        context.setVariable("channelID", applicationProperties.getSlack().getUserRegistrationChannelID());
+        context.setVariable("slackBaseUrl", applicationProperties.getSlack().getSlackBaseUrl());
+        context.setVariable("channelID", applicationProperties.getSlack().getUserRegistrationChannelId());
 
         String content = templateEngine.process("mail/" + LIST_OF_UNAPPROVED_USERS.getTemplateName(), context);
 

--- a/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
@@ -432,8 +432,8 @@ public class SlackService {
         try {
             String daysAgoTs = Long.toString(Instant.now().getEpochSecond() - DAY_IN_SECONDS * daysAgo);
             ConversationsHistoryResponse conversationsHistory = slack.methods().conversationsHistory(r -> r
-                .token(applicationProperties.getSlack().getSlackBotOAuthToken())
-                .channel(applicationProperties.getSlack().getUserRegistrationChannelID())
+                .token(applicationProperties.getSlack().getSlackBotOauthToken())
+                .channel(applicationProperties.getSlack().getUserRegistrationChannelId())
                 .oldest(daysAgoTs)
                 .limit(1000)
                 .inclusive(true));


### PR DESCRIPTION
When map yaml to java variable, we use . before each upper case characters which results to  application.slack.base.u.r.l. This is not what we are expecting in the settings

Signed-off-by: Hongxin <5400599+zhx828@users.noreply.github.com>