### PR TITLE
Add Dropdown Menu to Slack Integration

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/application/ApplicationProperties.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/application/ApplicationProperties.java
@@ -161,21 +161,21 @@ public class ApplicationProperties {
     }
 
     public List<String> getAcademicEmailClarifyDomains() {
-        return getDomains(this.getAcademicEmailClarifyDomain());
+        return getList(this.getAcademicEmailClarifyDomain());
     }
 
     public List<String> getLicensedDomainsList() {
-        return getDomains(this.getLicensedDomains());
+        return getList(this.getLicensedDomains());
     }
     public List<String> getTrialedDomainsList() {
-        return getDomains(this.getTrialedDomains());
+        return getList(this.getTrialedDomains());
     }
 
-    private List<String> getDomains(String domainStr) {
-        if (StringUtils.isEmpty(domainStr)) {
+    private List<String> getList(String listStr) {
+        if (StringUtils.isEmpty(listStr)) {
             return new ArrayList<>();
         }
-        return Arrays.stream(domainStr.split(",")).map(domain -> domain.trim()).filter(domain -> !StringUtils.isEmpty(domain)).collect(Collectors.toList());
+        return Arrays.stream(listStr.split(",")).map(element -> element.trim()).filter(element -> !StringUtils.isEmpty(element)).collect(Collectors.toList());
     }
 
     public AWSProperties getAws() {

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/UserStatusChecks.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/UserStatusChecks.java
@@ -1,0 +1,41 @@
+package org.mskcc.cbio.oncokb.domain;
+
+import org.mskcc.cbio.oncokb.service.SlackService;
+import org.mskcc.cbio.oncokb.service.UserService;
+import org.mskcc.cbio.oncokb.service.dto.UserDTO;
+
+/**
+ * Created by Benjamin Xu on 7/13/21.
+ */
+public class UserStatusChecks {
+    UserDTO userDTO;
+
+    boolean trialAccountActivated;
+    boolean trialAccountInitiated;
+    boolean academicClarificationEmailSent;
+
+    public UserStatusChecks(UserDTO userDTO, boolean trialAccountActivated, boolean trialAccountInitiated, boolean academicClarificationEmailSent) {
+        this.userDTO = userDTO;
+        this.trialAccountActivated = trialAccountActivated;
+        this.trialAccountInitiated = trialAccountInitiated;
+        this.academicClarificationEmailSent = academicClarificationEmailSent;
+    }
+
+    public boolean isTrialAccountActivated() { return trialAccountActivated; }
+
+    public void setTrialAccountActivated(boolean trialAccountActivated) { this.trialAccountActivated = trialAccountActivated; }
+
+    public boolean isTrialAccountInitiated() { return trialAccountInitiated; }
+
+    public void setTrialAccountInitiated(boolean trialAccountInitiated) { this.trialAccountInitiated = trialAccountInitiated; }
+
+    public boolean isAcademicClarificationEmailSent() { return academicClarificationEmailSent; }
+
+    public void setAcademicClarificationEmailSent(boolean academicClarificationEmailSent) { this.academicClarificationEmailSent = academicClarificationEmailSent; }
+
+    public boolean isReviewed() {
+        return userDTO.isActivated() || trialAccountInitiated || academicClarificationEmailSent;
+    }
+
+    public boolean isTrialAccount() { return trialAccountInitiated && (!userDTO.isActivated() || trialAccountActivated); }
+}

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/enumeration/LicenseType.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/enumeration/LicenseType.java
@@ -16,9 +16,7 @@ public enum LicenseType {
         this.shortName = shortName;
     }
 
-    public String getName() {
-        return name;
-    }
+    public String getName() { return name; }
 
     public String getShortName() { return shortName; }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/UserMailsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/UserMailsRepository.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * Spring Data  repository for the UserMails entity.
+ * Spring Data repository for the UserMails entity.
  */
 @SuppressWarnings("unused")
 @Repository

--- a/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
@@ -250,6 +250,11 @@ public class MailService {
     }
 
     @Async
+    public void sendAcademicClarificationEmail(UserDTO user) {
+        sendEmailWithLicenseContext(user, MailType.CLARIFY_ACADEMIC_NON_INSTITUTE_EMAIL, applicationProperties.getEmailAddresses().getLicenseAddress(), null, null);
+    }
+
+    @Async
     public void sendTrialAccountExpiresMail(int expiresInDays, List<UserDTO> users) {
         if (users == null || users.isEmpty()) {
             return;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
@@ -251,7 +251,7 @@ public class MailService {
 
     @Async
     public void sendAcademicClarificationEmail(UserDTO user) {
-        sendEmailWithLicenseContext(user, MailType.CLARIFY_ACADEMIC_NON_INSTITUTE_EMAIL, applicationProperties.getEmailAddresses().getLicenseAddress(), null, null);
+        sendEmailWithLicenseContext(user, MailType.CLARIFY_ACADEMIC_NON_INSTITUTE_EMAIL, applicationProperties.getEmailAddresses().getRegistrationAddress(), null, null);
     }
 
     @Async

--- a/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
@@ -15,13 +15,16 @@ import com.slack.api.webhook.WebhookResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.config.application.ApplicationProperties;
 import org.mskcc.cbio.oncokb.domain.UserIdMessagePair;
+import org.mskcc.cbio.oncokb.domain.UserStatusChecks;
 import org.mskcc.cbio.oncokb.domain.enumeration.*;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
+import org.mskcc.cbio.oncokb.service.mapper.UserMapper;
 import org.mskcc.cbio.oncokb.web.rest.slack.ActionId;
 import org.mskcc.cbio.oncokb.web.rest.slack.BlockId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
@@ -54,27 +57,32 @@ public class SlackService {
     private final ApplicationProperties applicationProperties;
     private final MailService mailService;
     private final EmailService emailService;
+    private final UserMailsService userMailsService;
 
-    public SlackService(ApplicationProperties applicationProperties, MailService mailService, EmailService emailService) {
+    @Autowired
+    private UserMapper userMapper;
+
+    public SlackService(ApplicationProperties applicationProperties, MailService mailService, EmailService emailService, UserMailsService userMailsService) {
         this.applicationProperties = applicationProperties;
         this.mailService = mailService;
         this.emailService = emailService;
+        this.userMailsService = userMailsService;
     }
 
     @Async
-    public void sendUserRegistrationToChannel(UserDTO user, boolean isTrialAccount, boolean trialAccountInitiated) {
+    public void sendUserRegistrationToChannel(UserDTO user, UserStatusChecks userStatusChecks) {
         log.debug("Sending notification to admin group that a user has registered a new account");
         if (StringUtils.isEmpty(this.applicationProperties.getSlack().getUserRegistrationWebhook())) {
             log.debug("\tSkipped, the webhook is not configured");
         } else {
-            List<LayoutBlock> layoutBlocks = this.buildBlocks(user, isTrialAccount, trialAccountInitiated, null);
+            List<LayoutBlock> layoutBlocks = this.buildBlocks(user, userStatusChecks, null);
             this.sendBlocks(this.applicationProperties.getSlack().getUserRegistrationWebhook(), layoutBlocks);
         }
     }
 
     @Async
-    public void sendLatestBlocks(String url, UserDTO userDTO, boolean isTrialAccount, boolean trialAccountInitiated, BlockActionPayload blockActionPayload) {
-        this.sendBlocks(url, this.buildBlocks(userDTO, isTrialAccount, trialAccountInitiated, blockActionPayload));
+    public void sendLatestBlocks(String url, UserDTO userDTO, UserStatusChecks userStatusChecks, BlockActionPayload blockActionPayload) {
+        this.sendBlocks(url, this.buildBlocks(userDTO, userStatusChecks, blockActionPayload));
     }
 
     @Async
@@ -120,6 +128,44 @@ public class SlackService {
         }
     }
 
+    public List<UserIdMessagePair> getAllUnapprovedUserRequestsSentAfter(int daysAgo) {
+        List<UserIdMessagePair> userList = new ArrayList<>();
+        Slack slack = Slack.getInstance();
+        final String REQUEST_MESSAGE_TEXT = "This content can't be displayed.";
+
+        try {
+            String daysAgoTs = Long.toString(Instant.now().getEpochSecond() - DAY_IN_SECONDS * daysAgo);
+            ConversationsHistoryResponse conversationsHistory = slack.methods().conversationsHistory(r -> r
+                .token(applicationProperties.getSlack().getSlackBotOauthToken())
+                .channel(applicationProperties.getSlack().getUserRegistrationChannelId())
+                .oldest(daysAgoTs)
+                .limit(1000)
+                .inclusive(true));
+            Collections.reverse(conversationsHistory.getMessages());
+            for (Message message : conversationsHistory.getMessages()) {
+                if (Objects.nonNull(message.getText()) && message.getText().equals(REQUEST_MESSAGE_TEXT) && Objects.nonNull(message.getBlocks())) {
+                    if (!(getBlockWithId(message.getBlocks(), COLLAPSED).isPresent()
+                        || getBlockWithId(message.getBlocks(), ACADEMIC_CLARIFICATION_NOTE).isPresent()
+                        || getBlockWithId(message.getBlocks(), MSK_USER_NOTE).isPresent()
+                        || getBlockWithId(message.getBlocks(), TRIAL_ACCOUNT_NOTE).isPresent()
+                        || getBlockWithId(message.getBlocks(), APPROVED_NOTE).isPresent()
+                        || getBlockWithId(message.getBlocks(), CONVERT_TO_REGULAR_ACCOUNT_NOTE).isPresent())
+                    ) {
+                        if (getBlockWithId(message.getBlocks(), USER_ID).isPresent()) {
+                            ContextBlock userIdBlock = (ContextBlock) getBlockWithId(message.getBlocks(), USER_ID).get();
+                            PlainTextObject userIdText = (PlainTextObject) userIdBlock.getElements().get(0);
+                            Long userId = Long.parseLong(userIdText.getText().substring(9));
+                            userList.add(new UserIdMessagePair(userId, message));
+                        }
+                    }
+                }
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("error: {}", e.getMessage(), e);
+        }
+        return userList;
+    }
+
     public ActionId getActionId(BlockActionPayload blockActionPayload) {
         List<String> actionIds = blockActionPayload.getActions().stream().map(action -> action.getActionId()).collect(Collectors.toList());
         for (String actionIdStr : actionIds) {
@@ -156,20 +202,22 @@ public class SlackService {
         }
     }
 
-    public List<LayoutBlock> buildBlocks(UserDTO userDTO, boolean isTrialAccount, boolean trialAccountInitiated, BlockActionPayload responseBlockActionPayload) {
+    public List<LayoutBlock> buildBlocks(UserDTO userDTO, UserStatusChecks userStatusChecks, BlockActionPayload responseBlockActionPayload) {
         List<LayoutBlock> blocks = new ArrayList<>();
-        ActionId actionId = null;
+        ActionId actionId;
+        boolean buildCollapsed = false;
         if (responseBlockActionPayload != null) {
             actionId = getActionId(responseBlockActionPayload);
+            boolean expandedAction = actionId.equals(EXPAND) || (actionId.equals(MORE_ACTIONS) && getActionIdFromMoreActions(responseBlockActionPayload).equals(UPDATE_USER)) || actionId.equals(CHANGE_LICENSE_TYPE);
+            buildCollapsed = (userStatusChecks.isReviewed() && !expandedAction) || actionId.equals(COLLAPSE);
         }
 
-        boolean collapsed = ((userDTO.isActivated() || trialAccountInitiated || isMSKUser(userDTO) || withClarificationNote(userDTO, false)) && !(actionId != null && (actionId.equals(EXPAND) || actionId.equals(UPDATE_USER) || actionId.equals(CHANGE_LICENSE_TYPE)))) || (actionId != null && actionId == COLLAPSE);
-        if (collapsed) {
+        if (buildCollapsed) {
             // Add collapsed blocks
-            blocks.add(buildCollapsedBlock(userDTO, isTrialAccount, trialAccountInitiated));
+            blocks.add(buildCollapsedBlock(userDTO, userStatusChecks));
         } else {
             // Add expanded blocks
-            blocks.addAll(buildExpandedBlocks(userDTO, isTrialAccount, trialAccountInitiated, responseBlockActionPayload));
+            blocks.addAll(buildExpandedBlocks(userDTO, userStatusChecks));
         }
 
         // Add message divider
@@ -178,12 +226,13 @@ public class SlackService {
         return blocks;
     }
 
-    private LayoutBlock buildCollapsedBlock(UserDTO userDTO, boolean isTrialAccount, boolean trialAccountInitiated) {
-        boolean isTrial = trialAccountInitiated && (!userDTO.isActivated() || isTrialAccount);
-        return SectionBlock.builder().text(MarkdownTextObject.builder().text(userDTO.getEmail() + "\n" + userDTO.getCompany() + " (" + userDTO.getLicenseType().getShortName() + (isTrial ? ", *TRIAL*" : userDTO.isActivated() ? "" : ", *NOT ACTIVATED*") + ")").build()).accessory(buildExpandButton(userDTO)).blockId(COLLAPSED.getId()).build();
+    private LayoutBlock buildCollapsedBlock(UserDTO userDTO, UserStatusChecks userStatusChecks) {
+        return SectionBlock.builder()
+            .text(MarkdownTextObject.builder().text(userDTO.getEmail() + "\n" + userDTO.getCompany() + " (" + userDTO.getLicenseType().getShortName() + (userStatusChecks.isTrialAccount() ? ", *TRIAL*" : userDTO.isActivated() ? "" : ", *NOT ACTIVATED*") + ")").build())
+            .accessory(buildExpandButton(userDTO)).blockId(COLLAPSED.getId()).build();
     }
 
-    private List<LayoutBlock> buildExpandedBlocks(UserDTO userDTO, boolean isTrialAccount, boolean trialAccountInitiated, BlockActionPayload responseBlockActionPayload) {
+    private List<LayoutBlock> buildExpandedBlocks(UserDTO userDTO, UserStatusChecks userStatusChecks) {
         List<LayoutBlock> blocks = new ArrayList<>();
 
         // Add mention
@@ -199,16 +248,16 @@ public class SlackService {
         blocks.add(buildCurrentLicense(userDTO));
 
         // Add account status
-        blocks.add(buildAccountStatusBlock(userDTO, isTrialAccount));
+        blocks.add(buildAccountStatusBlock(userDTO, userStatusChecks.isTrialAccountActivated()));
 
         // Add user info section
         blocks.addAll(buildUserInfoBlocks(userDTO));
 
         // Add additional info section
-        blocks.addAll(buildAdditionalInfoBlocks(userDTO, isTrialAccount, trialAccountInitiated));
+        blocks.addAll(buildAdditionalInfoBlocks(userDTO, userStatusChecks));
 
         // Add action section
-        blocks.addAll(buildActionBlocks(userDTO, trialAccountInitiated, isTrialAccount));
+        blocks.add(buildActionBlock(userDTO, userStatusChecks));
 
         return blocks;
     }
@@ -268,20 +317,20 @@ public class SlackService {
                 .build();
     }
 
-    private LayoutBlock buildAccountStatusBlock(UserDTO userDTO, boolean isTrialAccount) {
+    private LayoutBlock buildAccountStatusBlock(UserDTO userDTO, boolean isTrialAccountActivated) {
         List<TextObject> userInfo = new ArrayList<>();
 
         // Add account information
         userInfo.add(getTextObject("Account Status", userDTO.isActivated() ? "Activated" : (StringUtils.isNotEmpty(userDTO.getActivationKey()) ? "Email not validated" : "Not Activated")));
-        userInfo.add(getTextObject("Account Type", isTrialAccount ? "TRIAL" : "REGULAR"));
-        if (isTrialAccount) {
+        userInfo.add(getTextObject("Account Type", isTrialAccountActivated ? "TRIAL" : "REGULAR"));
+        if (isTrialAccountActivated) {
             userInfo.add(getTextObject("Trial Expires On", toNYZoneTime(userDTO.getAdditionalInfo().getTrialAccount().getActivation().getActivationDate().plusSeconds(DAY_IN_SECONDS * 90))));
         }
         return SectionBlock.builder().fields(userInfo).blockId(ACCOUNT_STATUS.getId()).build();
     }
 
-    private String getOptionValue(LicenseType licenseType, String login) {
-        return String.join(VALUE_SEPARATOR, licenseType.toString(), login);
+    private String getOptionValue(String argument, String login) {
+        return String.join(VALUE_SEPARATOR, argument, login);
     }
 
     public String getOptionValueLogin(String value) {
@@ -289,19 +338,22 @@ public class SlackService {
         return values[1];
     }
 
-    public String getOptionValueLicenseType(String value) {
+    public String getOptionValueArgument(String value) {
         String[] values = value.split(VALUE_SEPARATOR);
         return values[0];
     }
 
-    public boolean withClarificationNote(UserDTO userDTO, boolean sendEmail) {
+    public boolean withClarificationNote(UserDTO userDTO, boolean newUserActivation) {
         boolean withClarificationNote = false;
-        if (userDTO.getLicenseType().equals(LicenseType.ACADEMIC) &&
-            this.applicationProperties.getAcademicEmailClarifyDomains().size() > 0 &&
-            this.applicationProperties.getAcademicEmailClarifyDomains().stream().filter(domain -> userDTO.getEmail().endsWith(domain)).collect(Collectors.toList()).size() > 0) {
-            withClarificationNote = true;
-            if (sendEmail) {
-                mailService.sendEmailWithLicenseContext(userDTO, MailType.CLARIFY_ACADEMIC_NON_INSTITUTE_EMAIL, applicationProperties.getEmailAddresses().getLicenseAddress(), null, null);
+        if (userDTO.getLicenseType().equals(LicenseType.ACADEMIC)) {
+            if (!this.applicationProperties.getAcademicEmailClarifyDomains().isEmpty() &&
+                this.applicationProperties.getAcademicEmailClarifyDomains().stream().filter(domain -> userDTO.getEmail().endsWith(domain)).collect(Collectors.toList()).size() > 0) {
+                withClarificationNote = true;
+                if (newUserActivation) {
+                    mailService.sendAcademicClarificationEmail(userDTO);
+                }
+            } else if (!newUserActivation && !userMailsService.findUserMailsByUserAndMailTypeAndSentDateAfter(userMapper.userDTOToUser(userDTO), MailType.CLARIFY_ACADEMIC_NON_INSTITUTE_EMAIL, null).isEmpty()) {
+                withClarificationNote = true;
             }
         }
         return withClarificationNote;
@@ -313,7 +365,7 @@ public class SlackService {
             if (userDTO.getLicenseType() != licenseType) {
                 options.add(OptionObject
                     .builder()
-                    .value(this.getOptionValue(licenseType, userDTO.getLogin()))
+                    .value(this.getOptionValue(licenseType.toString(), userDTO.getLogin()))
                     .text(PlainTextObject.builder().text(licenseType.getName()).build())
                     .build());
             }
@@ -377,7 +429,7 @@ public class SlackService {
         return blocks;
     }
 
-    private List<LayoutBlock> buildAdditionalInfoBlocks(UserDTO userDTO, boolean isTrialAccount, boolean trialAccountInitiated) {
+    private List<LayoutBlock> buildAdditionalInfoBlocks(UserDTO userDTO, UserStatusChecks userStatusChecks) {
         List<LayoutBlock> layoutBlocks = new ArrayList<>();
 
         if (withClarificationNote(userDTO, false)) {
@@ -386,55 +438,20 @@ public class SlackService {
         if (isMSKUser(userDTO)) {
             layoutBlocks.add(buildPlainTextBlock("The user has been approved and notified automatically. We also changed their license to Academic and clarified with the user.", MSK_USER_NOTE));
         }
-        if (userDTO.getLicenseType() != LicenseType.ACADEMIC && trialAccountInitiated && (!userDTO.isActivated() || isTrialAccount)) {
-                layoutBlocks.add(buildPlainTextBlock("The trial account has been initialized and notified.", TRIAL_ACCOUNT_NOTE));
-        } else if (!trialAccountInitiated && userDTO.isActivated()) {
+        if (userDTO.isActivated() && !userStatusChecks.isTrialAccountActivated()) {
+            if (!userStatusChecks.isTrialAccountInitiated()) {
                 layoutBlocks.add(buildPlainTextBlock("The user has been approved and notified.", APPROVED_NOTE));
-        } else if (trialAccountInitiated && userDTO.isActivated() && !isTrialAccount) {
+            } else {
                 layoutBlocks.add(buildPlainTextBlock("The trial account has been converted to a regular account.", CONVERT_TO_REGULAR_ACCOUNT_NOTE));
+            }
+        } else if (userStatusChecks.isTrialAccountInitiated()) {
+            layoutBlocks.add(buildPlainTextBlock("The trial account has been initialized and notified.", TRIAL_ACCOUNT_NOTE));
         }
 
         return layoutBlocks;
     }
 
-    public List<UserIdMessagePair> getAllUnapprovedUserRequestsSentAfter(int daysAgo) {
-        List<UserIdMessagePair> userList = new ArrayList<>();
-        Slack slack = Slack.getInstance();
-        try {
-            String daysAgoTs = Long.toString(Instant.now().getEpochSecond() - DAY_IN_SECONDS * daysAgo);
-            ConversationsHistoryResponse conversationsHistory = slack.methods().conversationsHistory(r -> r
-                .token(applicationProperties.getSlack().getSlackBotOauthToken())
-                .channel(applicationProperties.getSlack().getUserRegistrationChannelId())
-                .oldest(daysAgoTs)
-                .limit(1000)
-                .inclusive(true));
-            Collections.reverse(conversationsHistory.getMessages());
-            for (Message message : conversationsHistory.getMessages()) {
-                if (Objects.nonNull(message.getText()) && message.getText().equals("This content can't be displayed.") && Objects.nonNull(message.getBlocks())) {
-                    if (!(getBlockWithId(message.getBlocks(), COLLAPSED).isPresent()
-                            || getBlockWithId(message.getBlocks(), ACADEMIC_CLARIFICATION_NOTE).isPresent()
-                            || getBlockWithId(message.getBlocks(), MSK_USER_NOTE).isPresent()
-                            || getBlockWithId(message.getBlocks(), TRIAL_ACCOUNT_NOTE).isPresent()
-                            || getBlockWithId(message.getBlocks(), APPROVED_NOTE).isPresent()
-                            || getBlockWithId(message.getBlocks(), CONVERT_TO_REGULAR_ACCOUNT_NOTE).isPresent())
-                    ) {
-                        if (getBlockWithId(message.getBlocks(), USER_ID).isPresent()) {
-                            ContextBlock userIdBlock = (ContextBlock) getBlockWithId(message.getBlocks(), USER_ID).get();
-                            PlainTextObject userIdText = (PlainTextObject) userIdBlock.getElements().get(0);
-                            Long userId = Long.parseLong(userIdText.getText().substring(9));
-                            userList.add(new UserIdMessagePair(userId, message));
-                        }
-                    }
-                }
-            }
-        } catch (IOException | SlackApiException e) {
-            log.error("error: {}", e.getMessage(), e);
-        }
-        return userList;
-    }
-
-    private List<LayoutBlock> buildActionBlocks(UserDTO userDTO, boolean trialAccountInitiated, boolean isTrialAccount) {
-        List<LayoutBlock> layoutBlocks = new ArrayList<>();
+    private LayoutBlock buildActionBlock(UserDTO userDTO, UserStatusChecks userStatusChecks) {
         List<BlockElement> actionElements = new ArrayList<>();
 
         // Add button - Approve
@@ -442,24 +459,10 @@ public class SlackService {
             actionElements.add(buildApproveButton(userDTO));
         }
 
-        // Add button - Give Trial Access
-        if (userDTO.getLicenseType() != LicenseType.ACADEMIC && !trialAccountInitiated && !userDTO.isActivated()) {
-            actionElements.add(buildGiveTrialAccessButton(userDTO));
-        }
+        // Add select element - More Actions
+        actionElements.add(buildMoreActionsDropdown(userDTO, userStatusChecks));
 
-        // Add button - Convert trial account to regular
-        if (isTrialAccount) {
-            actionElements.add(buildConvertToRegularAccountButton(userDTO));
-        }
-
-        // Add button - Collapse
-        actionElements.add(buildCollapseButton(userDTO));
-
-        // Add button - Update
-        actionElements.add(buildUpdateUserButton(userDTO));
-
-        layoutBlocks.add(ActionsBlock.builder().elements(actionElements).build());
-        return layoutBlocks;
+        return ActionsBlock.builder().elements(actionElements).build();
     }
 
     private ConfirmationDialogObject buildConfirmationDialogObject(String bodyText) {
@@ -472,10 +475,6 @@ public class SlackService {
         return confirmationDialogObject;
     }
 
-    private ButtonElement buildUpdateUserButton(UserDTO user) {
-        return buildButton("Update Info Above", user.getLogin(), UPDATE_USER);
-    }
-
     private ButtonElement buildApproveButton(UserDTO user) {
         ButtonElement button = buildPrimaryButton("Approve", user.getLogin(), APPROVE_USER);
         if (user.getLicenseType() != LicenseType.ACADEMIC) {
@@ -484,24 +483,70 @@ public class SlackService {
         return button;
     }
 
-    private ButtonElement buildGiveTrialAccessButton(UserDTO user) {
-        ButtonElement button = buildButton("Give Trial Access", user.getLogin(), GIVE_TRIAL_ACCESS);
+    private StaticSelectElement buildMoreActionsDropdown(UserDTO user, UserStatusChecks userStatusChecks) {
+        List<OptionGroupObject> optionGroups = new ArrayList<>();
+
         if (user.getLicenseType() != LicenseType.ACADEMIC) {
-            button.setConfirm(buildConfirmationDialogObject("You are going to give the user 3 month trial period. The user will get notified through email. Once they are ok with the free trial license agreement, their account will be activated."));
+            // Add option group - Trial
+            List<OptionObject> trialGroup = new ArrayList<>();
+            // Add option - Give Trial Access
+            if (!userStatusChecks.isTrialAccountInitiated() && !user.isActivated()) {
+                trialGroup.add(buildGiveTrialAccessOption(user));
+            }
+            // Add option - Convert to regular
+            if (userStatusChecks.isTrialAccountActivated()) {
+                trialGroup.add(buildConvertToRegularAccountOption(user));
+            }
+            if (!trialGroup.isEmpty()) {
+                optionGroups.add(OptionGroupObject.builder().label(PlainTextObject.builder().text("Trial").build()).options(trialGroup).build());
+            }
         }
-        return button;
+
+        // Add option group - Clarify
+        List<OptionObject> clarifyGroup = new ArrayList<>();
+        // Add option - Send Academic Clarification Email
+        clarifyGroup.add(buildAcademicClarificationOption(user));
+        optionGroups.add(OptionGroupObject.builder().label(PlainTextObject.builder().text("Clarify").build()).options(clarifyGroup).build());
+
+        // Add option group - Other
+        List<OptionObject> otherGroup = new ArrayList<>();
+        // Add option - Collapse
+        otherGroup.add(buildCollapseOption(user));
+        // Add option - Update Info
+        otherGroup.add(buildUpdateUserOption(user));
+        optionGroups.add(OptionGroupObject.builder().label(PlainTextObject.builder().text("Other").build()).options(otherGroup).build());
+
+        StaticSelectElement dropdown = StaticSelectElement.builder().actionId(MORE_ACTIONS.getId()).placeholder(PlainTextObject.builder().text("More Actions").build()).optionGroups(optionGroups).build();
+        dropdown.setConfirm(buildConfirmationDialogObject("Please check that the correct action has been selected."));
+        return dropdown;
     }
 
-    private ButtonElement buildConvertToRegularAccountButton(UserDTO user) {
-        ButtonElement button = buildButton("Convert to regular account", user.getLogin(), CONVERT_TO_REGULAR_ACCOUNT);
-        if (user.getLicenseType() != LicenseType.ACADEMIC) {
-            button.setConfirm(buildConfirmationDialogObject("You are going to convert a trial account to regular."));
-        }
-        return button;
+    private OptionObject buildGiveTrialAccessOption(UserDTO user) {
+        return OptionObject.builder().value(getOptionValue(GIVE_TRIAL_ACCESS.toString(), user.getLogin())).text(PlainTextObject.builder().text("Give Trial Access").build()).build();
     }
 
-    private ButtonElement buildCollapseButton(UserDTO user) {
-        return buildButton("Collapse", user.getLogin(), COLLAPSE);
+    private OptionObject buildConvertToRegularAccountOption(UserDTO user) {
+        return OptionObject.builder().value(getOptionValue(CONVERT_TO_REGULAR_ACCOUNT.toString(), user.getLogin())).text(PlainTextObject.builder().text("Convert To Regular Account").build()).build();
+    }
+
+    private OptionObject buildAcademicClarificationOption(UserDTO user) {
+        return OptionObject.builder().value(getOptionValue(SEND_ACADEMIC_CLARIFICATION_EMAIL.toString(), user.getLogin())).text(PlainTextObject.builder().text("Send Academic Domain Clarification Email").build()).build();
+    }
+
+    private OptionObject buildCollapseOption(UserDTO user) {
+        return OptionObject.builder().value(getOptionValue(COLLAPSE.toString(), user.getLogin())).text(PlainTextObject.builder().text("Collapse").build()).build();
+    }
+
+    private OptionObject buildUpdateUserOption(UserDTO user) {
+        return OptionObject.builder().value(getOptionValue(UPDATE_USER.toString(), user.getLogin())).text(PlainTextObject.builder().text("Update Info Above").build()).build();
+    }
+
+    public ActionId getActionIdFromMoreActions(BlockActionPayload blockActionPayload) {
+        if (blockActionPayload != null) {
+            BlockActionPayload.Action action = getAction(blockActionPayload, MORE_ACTIONS).orElse(null);
+            return ActionId.valueOf(getOptionValueArgument(action.getSelectedOption().getValue()));
+        }
+        return null;
     }
 
     private ButtonElement buildExpandButton(UserDTO user) {

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserMailsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserMailsService.java
@@ -79,6 +79,10 @@ public class UserMailsService {
     @Transactional(readOnly = true)
     public List<UserMailsDTO> findUserMailsByUserAndMailTypeAndSentDateAfter(User user, MailType mailType, Instant sentAfter) {
         log.debug("Request to get all UserMails for a particular user");
+        if (sentAfter == null) {
+            sentAfter = Instant.EPOCH;
+        }
+
         return userMailsRepository.findUserMailsByUserAndMailTypeAndSentDateAfter(user, mailType, sentAfter).stream()
             .map(userMailsMapper::toDto)
             .collect(Collectors.toCollection(LinkedList::new));

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -264,7 +264,7 @@ public class UserService {
         return newUser;
     }
 
-    public boolean isTrialAccount(UserDTO userDTO) {
+    public boolean trialAccountActivated(UserDTO userDTO) {
         List<Token> tokens = tokenService.findByUser(userMapper.userDTOToUser(userDTO));
         return tokens.stream().filter(token -> !token.isRenewable()).findAny().isPresent();
     }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -4,6 +4,7 @@ package org.mskcc.cbio.oncokb.web.rest;
 import org.mskcc.cbio.oncokb.config.application.ApplicationProperties;
 import org.mskcc.cbio.oncokb.domain.Token;
 import org.mskcc.cbio.oncokb.domain.User;
+import org.mskcc.cbio.oncokb.domain.UserStatusChecks;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
 import org.mskcc.cbio.oncokb.domain.enumeration.MailType;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
@@ -180,7 +181,10 @@ public class AccountResource {
             mailService.sendEmailFromTemplate(userDTO, MailType.APPROVAL_MSK_IN_COMMERCIAL, context);
         }
         slackService.withClarificationNote(userDTO, true);
-        slackService.sendUserRegistrationToChannel(userDTO, userService.isTrialAccount(userDTO), userService.trialAccountInitiated(userDTO));
+        slackService.sendUserRegistrationToChannel(userDTO, new UserStatusChecks(userDTO,
+                userService.trialAccountActivated(userDTO),
+                userService.trialAccountInitiated(userDTO),
+                slackService.withClarificationNote(userDTO, false)));
         return false;
     }
 

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/slack/ActionId.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/slack/ActionId.java
@@ -6,12 +6,14 @@ package org.mskcc.cbio.oncokb.web.rest.slack;
  */
 public enum ActionId {
     APPROVE_USER("approve-user")
-    , UPDATE_USER("update-user")
     , CHANGE_LICENSE_TYPE("change-license-type")
     , GIVE_TRIAL_ACCESS("give-trial-access")
     , CONVERT_TO_REGULAR_ACCOUNT("convert-to-regular-account")
     , COLLAPSE("collapse")
     , EXPAND("expand")
+    , MORE_ACTIONS("more-actions")
+    , SEND_ACADEMIC_CLARIFICATION_EMAIL("send-academic-clarification-email")
+    , UPDATE_USER("update-user")
     ;
 
     String id;

--- a/src/main/resources/templates/mail/activateFreeTrial.html
+++ b/src/main/resources/templates/mail/activateFreeTrial.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
 </head>
 <body>
-<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName}"></p>
+<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
 <p th:if="${newAccountCreation}">
   Your OncoKB account has been created.

--- a/src/main/resources/templates/mail/approvalMSKInCommercial.html
+++ b/src/main/resources/templates/mail/approvalMSKInCommercial.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}"/>
 </head>
 <body>
-<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName}"></p>
+<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
 <p th:text="'Thank you for your interest in the ' + ${license} + ' license for OncoKB.'"></p>
 

--- a/src/main/resources/templates/mail/clarifyAcademicUseWithoutInstituteEmail.html
+++ b/src/main/resources/templates/mail/clarifyAcademicUseWithoutInstituteEmail.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
 </head>
 <body>
-<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName}"></p>
+<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
 <p th:text="'Thank you for your interest in the ' + ${license} + ' license for OncoKB.'"></p>
 

--- a/src/main/resources/templates/mail/clarifyLicenseInForProfileCompany.html
+++ b/src/main/resources/templates/mail/clarifyLicenseInForProfileCompany.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
 </head>
 <body>
-<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName}"></p>
+<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
 <p th:text="'Thank you for your interest in the ' + ${license} + ' license for OncoKB.'"></p>
 

--- a/src/main/resources/templates/mail/licenseReview.html
+++ b/src/main/resources/templates/mail/licenseReview.html
@@ -6,7 +6,7 @@
   <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
 </head>
 <body>
-<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName}"></p>
+<p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
 <p th:text="'Thank you for your interest in the ' + ${license} + ' license for OncoKB.'"></p>
 

--- a/src/main/resources/templates/mail/tokenHasBeenExposedToUser.html
+++ b/src/main/resources/templates/mail/tokenHasBeenExposedToUser.html
@@ -6,7 +6,7 @@
         <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
-        <p>Dear <b th:text="${token.firstName} + ' ' + ${token.lastName}"></b></p>
+        <p>Dear <b th:text="${token.firstName} + ' ' + ${token.lastName} + ','"></b></p>
         <p>We have become aware that your OncoKB token <b th:text="${token.token}"></b> was publicly availble on: <b th:text="${token.source}"></b>.</p>
         <p>
             This exposure of your token poses a security risk to your OncoKB account and could lead to unauthorized activities. 


### PR DESCRIPTION
### Changes to Slack Integration

- Non-approve buttons have been moved to a dropdown menu for organization
- Clarification and Denial emails can be sent in this menu (ignore embargo for now)

<img width="322" alt="Screen Shot 2021-07-14 at 11 41 37 AM" src="https://user-images.githubusercontent.com/71607240/125651209-e078aaeb-ed9e-4f0f-b2ea-b71e58bdb969.png">
<img width="321" alt="Screen Shot 2021-07-14 at 11 41 48 AM" src="https://user-images.githubusercontent.com/71607240/125651215-77a3713c-ca05-42d1-8e89-bdfe7072ddb7.png">

this fixes https://github.com/oncokb/oncokb/issues/2655