### PR TITLE
Fixed clarification email bug

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
@@ -214,6 +214,8 @@ public class SlackService {
             actionId = getActionId(responseBlockActionPayload);
             boolean expandedAction = actionId.equals(EXPAND) || (actionId.equals(MORE_ACTIONS) && getActionIdFromMoreActions(responseBlockActionPayload).equals(UPDATE_USER)) || actionId.equals(CHANGE_LICENSE_TYPE);
             buildCollapsed = (userStatusChecks.isReviewed() && !expandedAction) || actionId.equals(COLLAPSE);
+        } else {
+            buildCollapsed = userStatusChecks.isReviewed();
         }
 
         if (buildCollapsed) {
@@ -231,8 +233,16 @@ public class SlackService {
     }
 
     private LayoutBlock buildCollapsedBlock(UserDTO userDTO, UserStatusChecks userStatusChecks) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(userDTO.getEmail() + "\n" + userDTO.getCompany() + " (" + userDTO.getLicenseType().getShortName() + (userStatusChecks.isTrialAccount() ? ", *TRIAL*" : userDTO.isActivated() ? "" : ", *NOT ACTIVATED*"));
+        if (!userDTO.isActivated()) {
+            if (userStatusChecks.isAcademicClarificationEmailSent()) {
+                sb.append(":\nClarified with user on noninstitutional email");
+            }
+        }
+        sb.append(")");
         return SectionBlock.builder()
-            .text(MarkdownTextObject.builder().text(userDTO.getEmail() + "\n" + userDTO.getCompany() + " (" + userDTO.getLicenseType().getShortName() + (userStatusChecks.isTrialAccount() ? ", *TRIAL*" : userDTO.isActivated() ? "" : ", *NOT ACTIVATED*") + ")").build())
+            .text(MarkdownTextObject.builder().text(sb.toString()).build())
             .accessory(buildExpandButton(userDTO)).blockId(COLLAPSED.getId()).build();
     }
 

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -180,11 +180,10 @@ public class AccountResource {
             context.setVariable(MAIL_LICENSE, registeredLicenseType.getName());
             mailService.sendEmailFromTemplate(userDTO, MailType.APPROVAL_MSK_IN_COMMERCIAL, context);
         }
-        slackService.withClarificationNote(userDTO, true);
         slackService.sendUserRegistrationToChannel(userDTO, new UserStatusChecks(userDTO,
                 userService.trialAccountActivated(userDTO),
                 userService.trialAccountInitiated(userDTO),
-                slackService.withClarificationNote(userDTO, false)));
+                slackService.withClarificationNote(userDTO, true)));
         return false;
     }
 


### PR DESCRIPTION
Slack blocks were not collapsing automatically when the academic clarification email was sent. Now they automatically collapse to the following block:

<img width="695" alt="Screen Shot 2021-07-27 at 11 34 38 AM" src="https://user-images.githubusercontent.com/71607240/127183706-b7018a41-9a61-4aa8-b69b-e3a756790586.png">
