### PR TITLE
Do not show biological info for most of positional alts

### DIFF
--- a/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
@@ -32,6 +32,7 @@ import {
   getCancerTypeNameFromOncoTreeType,
   getDefaultColumnDefinition,
   getTreatmentNameFromEvidence,
+  isPositionalAlteration,
   levelOfEvidence2Level,
 } from 'app/shared/utils/Utils';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
@@ -430,6 +431,11 @@ export default class AnnotationPage extends React.Component<IAnnotationPage> {
           </span>
         </h2>
         <AlterationInfo
+          isPositionalAlteration={isPositionalAlteration(
+            this.props.annotation.query.proteinStart,
+            this.props.annotation.query.proteinEnd,
+            this.props.annotation.query.consequence
+          )}
           oncogenicity={this.props.annotation.oncogenic}
           mutationEffect={
             this.isOncogenicMutations

--- a/src/main/webapp/app/shared/utils/Utils.tsx
+++ b/src/main/webapp/app/shared/utils/Utils.tsx
@@ -489,3 +489,15 @@ export function encodeResourceUsageDetailPageURL(endpoint: string) {
 export function decodeResourceUsageDetailPageURL(url: string) {
   return url.split('!').join('/');
 }
+
+export function isPositionalAlteration(
+  proteinStart: number,
+  proteinEnd: number,
+  consequence: string
+) {
+  if (proteinStart && proteinEnd && consequence) {
+    return proteinStart === proteinEnd && consequence === 'NA';
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
If the positional alteration does not have curated biological information, we should not show the section on the public website

Signed-off-by: Hongxin <5400599+zhx828@users.noreply.github.com>

This fixes https://github.com/oncokb/oncokb/issues/2658