### PR TITLE
Rework token_stats storage

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
@@ -144,4 +144,13 @@ public class TokenStats implements Serializable {
             ", usageCount=" + getUsageCount() +
             "}";
     }
+
+    public String toCSV() {
+        return getId() +
+            ";" + getAccessIp() +
+            ";" + getResource() +
+            ";" + getAccessTime() +
+            ";" + getUsageCount() +
+            ";" + getToken().getId();
+    }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -26,4 +26,6 @@ public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     " where tokenStats.accessTime > ?1 " + 
     " group by tokenStats.token, DATE_FORMAT(tokenStats.accessTime,'%Y-%m'), tokenStats.resource")
     List<UserTokenUsageWithInfo> countTokenUsageByTokenTimeResource(Instant after);
+
+    void deleteAll();
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
@@ -46,6 +46,8 @@ public interface TokenStatsService {
 
     void removeOldTokenStats();
 
+    void clearTokenStats();
+
     List<UserTokenUsage> getUserTokenUsage(Instant before);
 
     List<UserTokenUsageWithInfo> getTokenUsageAnalysis(Instant after);

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
@@ -12,10 +12,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.BufferedWriter;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.io.FileWriter;
+import java.io.IOException;
 
 /**
  * Service Implementation for managing {@link TokenStats}.
@@ -38,7 +41,16 @@ public class TokenStatsServiceImpl implements TokenStatsService {
     @Override
     public TokenStats save(TokenStats tokenStats) {
         log.debug("Request to save TokenStats : {}", tokenStats);
-        return tokenStatsRepository.save(tokenStats);
+        tokenStats = tokenStatsRepository.save(tokenStats);
+        try {
+            FileWriter fileWriter = new FileWriter("src/main/resources/config/liquibase/data/token_stats.csv", true);
+            BufferedWriter bufferedWriter = new BufferedWriter(fileWriter);
+            bufferedWriter.append(tokenStats.toCSV() + "\n");
+            bufferedWriter.close();
+        } catch (IOException e) {
+            log.warn("Failed to save TokenStats : {}", tokenStats);
+        }
+        return tokenStats;
     }
 
     @Override
@@ -73,6 +85,10 @@ public class TokenStatsServiceImpl implements TokenStatsService {
                 log.debug("Deleting token stats", tokenStat);
                 tokenStatsRepository.delete(tokenStat);
             });
+    }
+
+    public void clearTokenStats() {
+        tokenStatsRepository.deleteAll();
     }
 
     public List<UserTokenUsage> getUserTokenUsage(Instant before) {

--- a/src/main/resources/config/liquibase/data/token_stats.csv
+++ b/src/main/resources/config/liquibase/data/token_stats.csv
@@ -1,0 +1,1 @@
+id;access_ip;resource;access_time;usage_count;token_id

--- a/src/main/resources/config/liquibase/old-token-stats/token_stats_placeholder.csv
+++ b/src/main/resources/config/liquibase/old-token-stats/token_stats_placeholder.csv
@@ -1,0 +1,2 @@
+id;access_ip;resource;access_time;usage_count;token_id
+ignore


### PR DESCRIPTION
### The token_stats table is now completely cleared periodically

In order to prevent the table from overflowing, all entries are deleted when the updateTokenStats() cronjob is called. This cronjob now just adds usage to each token's current usage instead of replacing it.

### Old token_stats backups are stored in a new directory liquibase/old-token-stats as .csv files

When TokenStats are saved, they are now also appended to a .csv file in liquibase/data. When updateTokenStats() is called, the file is moved to old-token-stats and the name is changed to include the current timestamp. A new file then takes its place.

This fixes https://github.com/oncokb/oncokb/issues/2648