### PR TITLE
Allow admin to register user using an existing company's info.

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/repository/CompanyRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/CompanyRepository.java
@@ -1,5 +1,7 @@
 package org.mskcc.cbio.oncokb.repository;
 
+import java.util.Optional;
+
 import org.mskcc.cbio.oncokb.domain.Company;
 
 import org.springframework.data.jpa.repository.*;
@@ -11,4 +13,6 @@ import org.springframework.stereotype.Repository;
 @SuppressWarnings("unused")
 @Repository
 public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+    Optional<Company> findOneByNameIgnoreCase(String name);
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/CompanyService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/CompanyService.java
@@ -42,6 +42,14 @@ public interface CompanyService {
     Optional<CompanyDTO> findOne(Long id);
 
     /**
+     * Get the "name" company.
+     *
+     * @param name the name of the entity.
+     * @return the entity.
+     */
+    Optional<CompanyDTO> findOneByNameIgnoreCase(String name);
+
+    /**
      * Delete the "id" company.
      *
      * @param id the id of the entity.

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -39,8 +39,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import javax.swing.text.DefaultStyledDocument.ElementSpec;
-
 import static org.mskcc.cbio.oncokb.config.Constants.*;
 import static org.mskcc.cbio.oncokb.config.cache.UserCacheResolver.USERS_BY_EMAIL_CACHE;
 import static org.mskcc.cbio.oncokb.config.cache.UserCacheResolver.USERS_BY_LOGIN_CACHE;
@@ -341,8 +339,10 @@ public class UserService {
         userDetails.setCompanyName(userDTO.getCompanyName());
         userDetails.setCity(userDTO.getCity());
         userDetails.setCountry(userDTO.getCountry());
+        userDetails.setCompany(userDTO.getCompany());
         userDetailsRepository.save(userDetails);
 
+        
         // Check if the user is apart of licensed company and then continue with approval procedure
         Optional<Company> company = findAssociatedCompany(userDTO);
         company.ifPresent(c -> updateUserWithCompanyLicense(user, c));
@@ -623,6 +623,11 @@ public class UserService {
      * @param userDTO the user
      */
     private Optional<Company> findAssociatedCompany(UserDTO userDTO) {
+        
+        if(userDTO.getCompany() != null){
+            return companyRepository.findById(userDTO.getCompany().getId());
+        }
+
         String domain = StringUtil.getEmailDomain(userDTO.getEmail());
         List<CompanyDomain> companyDomains = companyDomainRepository.findByName(domain);
         if(companyDomains.size() > 0) {

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/UserDTO.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/UserDTO.java
@@ -188,6 +188,10 @@ public class UserDTO {
         return company;
     }
 
+    public void setCompany(Company company) {
+        this.company = company;
+    }
+
     public String getCity() {
         return city;
     }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/CompanyServiceImpl.java
@@ -152,6 +152,13 @@ public class CompanyServiceImpl implements CompanyService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Optional<CompanyDTO> findOneByNameIgnoreCase(String name) {
+        log.debug("Request to get Company by name: {}", name);
+        return companyRepository.findOneByNameIgnoreCase(name).map(company -> companyMapper.toDto(company));
+    }
+
+    @Override
     public void delete(Long id) {
         log.debug("Request to delete Company : {}", id);
         companyRepository.deleteById(id);

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -367,7 +367,7 @@ public class AccountResource {
     }
 
     @PostMapping(path = "/account/active-trial/finish")
-    public UserDTO finishTrialAccountActivation(@RequestBody KeyAndTermsVM keyAndTermsVM) {
+    public UserDTO finishTrialAccountActivation(@RequestBody KeyAndTermsVM keyAndTermsVM, @RequestParam Boolean newAccountCreation) {
         if (keyAndTermsVM.getReadAndAgreeWithTheTerms() != Boolean.TRUE) {
             throw new AccountResourceException("You have to read and agree with the terms.");
         }
@@ -375,6 +375,10 @@ public class AccountResource {
         if (userDetailsDTO.isPresent()) {
             Optional<UserDTO> userDTOOptional = userService.finishTrialAccountActivation(keyAndTermsVM.getKey());
             if (userDTOOptional.isPresent()) {
+                // After the user agrees with the terms and is a newly created user, send the OncoKB account is created email.
+                if(newAccountCreation){
+                    mailService.sendCreationEmail(userDTOOptional.get());
+                }
                 return userDTOOptional.get();
             }
         }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -367,7 +367,7 @@ public class AccountResource {
     }
 
     @PostMapping(path = "/account/active-trial/finish")
-    public UserDTO finishTrialAccountActivation(@RequestBody KeyAndTermsVM keyAndTermsVM, @RequestParam Boolean newAccountCreation) {
+    public UserDTO finishTrialAccountActivation(@RequestBody KeyAndTermsVM keyAndTermsVM) {
         if (keyAndTermsVM.getReadAndAgreeWithTheTerms() != Boolean.TRUE) {
             throw new AccountResourceException("You have to read and agree with the terms.");
         }
@@ -375,10 +375,6 @@ public class AccountResource {
         if (userDetailsDTO.isPresent()) {
             Optional<UserDTO> userDTOOptional = userService.finishTrialAccountActivation(keyAndTermsVM.getKey());
             if (userDTOOptional.isPresent()) {
-                // After the user agrees with the terms and is a newly created user, send the OncoKB account is created email.
-                if(newAccountCreation){
-                    mailService.sendCreationEmail(userDTOOptional.get());
-                }
                 return userDTOOptional.get();
             }
         }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CompanyResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CompanyResource.java
@@ -6,7 +6,6 @@ import org.mskcc.cbio.oncokb.web.rest.errors.BadRequestAlertException;
 import org.mskcc.cbio.oncokb.web.rest.vm.CompanyVM;
 import org.mskcc.cbio.oncokb.service.dto.CompanyDTO;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
-import org.mskcc.cbio.oncokb.service.dto.UserDetailsDTO;
 
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
@@ -57,6 +56,8 @@ public class CompanyResource {
         log.debug("REST request to save Company : {}", companyDTO);
         if (companyDTO.getId() != null) {
             throw new BadRequestAlertException("A new company cannot already have an ID", ENTITY_NAME, "idexists");
+        }else if(companyService.findOneByNameIgnoreCase(companyDTO.getName()).isPresent()){
+            throw new BadRequestAlertException("Company name already in use.", ENTITY_NAME, "nameexists");
         }
         CompanyDTO result = companyService.createCompany(companyDTO);
         return ResponseEntity.created(new URI("/api/companies/" + result.getId()))
@@ -113,6 +114,18 @@ public class CompanyResource {
     public List<UserDTO> getCompanyUsers(@PathVariable Long id) {
         log.debug("REST request to all users associated to Company : {}", id);
         return userService.getUsersOfCompany(id);
+    }
+
+    /**
+     * {@code GET /companies?name} : get the "name" company.
+     *
+     * @param name the name of the company to find.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the "name" company, or with status {@code 404 (Not Found)}.
+     */
+    @GetMapping("/companies/name/{name}")
+    public ResponseEntity<CompanyDTO> getCompanyByName(@PathVariable String name) {
+        log.debug("REST request to get Company : {}", name);
+        return ResponseUtil.wrapOrNotFound(companyService.findOneByNameIgnoreCase(name));
     }
 
     /**

--- a/src/main/resources/templates/mail/activateFreeTrial.html
+++ b/src/main/resources/templates/mail/activateFreeTrial.html
@@ -8,17 +8,26 @@
 <body>
 <p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
+<p th:if="${newAccountCreation}">
+  Your OncoKB account has been created.
+</p>
+
 <p>
   As part of your company's trial and evaluation of OncoKB, below is your activation link for a 3 month trial of OncoKB:
 </p>
 
 <p>
-  <a th:with="url=(@{|${baseUrl}/account/active-trial/finish?key=${user.additionalInfo.trialAccount.activation.key}&newAccountCreation=${newAccountCreation}|})" th:href="${url}"
+  <a th:with="url=(@{|${baseUrl}/account/active-trial/finish?key=${user.additionalInfo.trialAccount.activation.key}|})" th:href="${url}"
      th:text="${url}">Trial Activation Link</a>
 </p>
 
-<p>
-  After accepting the terms, you will receive an email to activate your OncoKB account.
+<p th:if="${newAccountCreation}">
+  After accepting the terms, please follow the instruction to reset your password. Below is the URL for your convenience.
+</p>
+
+<p th:if="${newAccountCreation}">
+  <a th:with="url=(@{|${baseUrl}/account/reset/finish?key=${user.resetKey}|})" th:href="${url}"
+     th:text="${url}">Reset Password link</a>
 </p>
 
 <p>Please let us know if you have any questions. We look forward to working with you.</p>

--- a/src/main/resources/templates/mail/activateFreeTrial.html
+++ b/src/main/resources/templates/mail/activateFreeTrial.html
@@ -8,31 +8,17 @@
 <body>
 <p th:text="'Dear ' + ${user.firstName} + ' ' + ${user.lastName} + ','"></p>
 
-<p th:if="${newAccountCreation}">
-  Your OncoKB account has been created.
-</p>
-
 <p>
   As part of your company's trial and evaluation of OncoKB, below is your activation link for a 3 month trial of OncoKB:
 </p>
 
 <p>
-  <a th:with="url=(@{|${baseUrl}/account/active-trial/finish?key=${user.additionalInfo.trialAccount.activation.key}|})" th:href="${url}"
+  <a th:with="url=(@{|${baseUrl}/account/active-trial/finish?key=${user.additionalInfo.trialAccount.activation.key}&newAccountCreation=${newAccountCreation}|})" th:href="${url}"
      th:text="${url}">Trial Activation Link</a>
 </p>
 
-<p th:if="${licenseMismatch}">
-  Be aware that your account was registered with a different license and has
-  been changed to match your company's license.
-</p>
-
-<p th:if="${newAccountCreation}">
-  After accepting the terms, please follow the instruction to reset your password. Below is the URL for your convince.
-</p>
-
-<p th:if="${newAccountCreation}">
-  <a th:with="url=(@{|${baseUrl}/account/reset/finish?key=${user.resetKey}|})" th:href="${url}"
-     th:text="${url}">Reset Password link</a>
+<p>
+  After accepting the terms, you will receive an email to activate your OncoKB account.
 </p>
 
 <p>Please let us know if you have any questions. We look forward to working with you.</p>

--- a/src/main/resources/templates/mail/approvalEmail.html
+++ b/src/main/resources/templates/mail/approvalEmail.html
@@ -16,10 +16,7 @@
           <a th:with="url=(@{|${baseUrl}/login|})" th:href="${url}"
                th:text="${url}">Login link</a>
         </p>
-        <p th:if="${licenseMismatch}">
-            Be aware that your account was registered with a different license and has
-            been changed to match your company's license.
-        </p>
+
         <p>
             <div th:text="#{email.closing}">Sincerely, </div>
             <div th:text="#{email.signature}">The OncoKB Team</div>

--- a/src/main/webapp/app/components/account/ActivateTrialFinish.tsx
+++ b/src/main/webapp/app/components/account/ActivateTrialFinish.tsx
@@ -36,6 +36,7 @@ export default class ActivateTrialFinish extends React.Component<{
   @observable loadingActivationInfo = true;
   @observable user: UserDTO;
   private activateKey: string;
+  private newAccountCreation: boolean;
   @observable infoMessage: string | JSX.Element;
 
   constructor(props: Readonly<{ routing: RouterStore }>) {
@@ -43,6 +44,9 @@ export default class ActivateTrialFinish extends React.Component<{
     const queryStrings = QueryString.parse(props.routing.location.search);
     if (queryStrings.key) {
       this.activateKey = queryStrings.key as string;
+    }
+    if (queryStrings.newAccountCreation) {
+      this.newAccountCreation = queryStrings.newAccountCreation === 'true';
     }
   }
 
@@ -53,6 +57,7 @@ export default class ActivateTrialFinish extends React.Component<{
           key: this.activateKey,
           readAndAgreeWithTheTerms: true,
         },
+        newAccountCreation: this.newAccountCreation,
       })
       .then(
         user => {

--- a/src/main/webapp/app/components/account/ActivateTrialFinish.tsx
+++ b/src/main/webapp/app/components/account/ActivateTrialFinish.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { RouterStore } from 'mobx-react-router';
-import {
-  PAGE_ROUTE,
-  REDIRECT_TIMEOUT_MILLISECONDS,
-  XREGEXP_VALID_LATIN_TEXT,
-} from 'app/config/constants';
+import { PAGE_ROUTE, XREGEXP_VALID_LATIN_TEXT } from 'app/config/constants';
 import { inject, observer } from 'mobx-react';
 import { Button, ResponsiveEmbed, Row, Col, Tabs, Tab } from 'react-bootstrap';
 import SmallPageContainer from '../SmallPageContainer';
@@ -36,7 +32,6 @@ export default class ActivateTrialFinish extends React.Component<{
   @observable loadingActivationInfo = true;
   @observable user: UserDTO;
   private activateKey: string;
-  private newAccountCreation: boolean;
   @observable infoMessage: string | JSX.Element;
 
   constructor(props: Readonly<{ routing: RouterStore }>) {
@@ -44,9 +39,6 @@ export default class ActivateTrialFinish extends React.Component<{
     const queryStrings = QueryString.parse(props.routing.location.search);
     if (queryStrings.key) {
       this.activateKey = queryStrings.key as string;
-    }
-    if (queryStrings.newAccountCreation) {
-      this.newAccountCreation = queryStrings.newAccountCreation === 'true';
     }
   }
 
@@ -57,7 +49,6 @@ export default class ActivateTrialFinish extends React.Component<{
           key: this.activateKey,
           readAndAgreeWithTheTerms: true,
         },
-        newAccountCreation: this.newAccountCreation,
       })
       .then(
         user => {
@@ -76,7 +67,7 @@ export default class ActivateTrialFinish extends React.Component<{
             } else {
               this.infoMessage = <Redirect to={PAGE_ROUTE.LOGIN} />;
             }
-          }, REDIRECT_TIMEOUT_MILLISECONDS);
+          }, 3000);
         },
         (error: Error) => {
           notifyError(error);

--- a/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
+++ b/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
@@ -13,6 +13,7 @@ import { action, computed, observable } from 'mobx';
 import autobind from 'autobind-decorator';
 import {
   AdditionalInfoDTO,
+  CompanyDTO,
   Contact,
   ManagedUserVM,
 } from 'app/shared/api/generated/API';
@@ -34,6 +35,9 @@ import {
 } from 'app/pages/account/AccountUtils';
 import { If, Then } from 'react-if';
 import _ from 'lodash';
+import { FormSelectWithLabelField } from 'app/shared/select/FormSelectWithLabelField';
+import client from 'app/shared/api/clientInstance';
+import { notifyError } from 'app/shared/utils/NotificationUtils';
 
 export enum FormSection {
   LICENSE = 'LICENSE',
@@ -63,12 +67,19 @@ enum FormKey {
   BUS_CONTACT_PHONE = 'businessContactPhone',
 }
 
+type CompanySelectOptionType = {
+  label: string;
+  value: CompanyDTO;
+};
+
 export const ACCOUNT_TYPE_DEFAULT = AccountType.REGULAR;
 @observer
 export class NewAccountForm extends React.Component<INewAccountForm> {
   @observable password = '';
   @observable selectedLicense: LicenseType | undefined;
   @observable selectedAccountType = ACCOUNT_TYPE_DEFAULT;
+  @observable companyOptions: CompanySelectOptionType[] = [];
+  @observable selectedCompanyOption: CompanySelectOptionType | undefined;
 
   private defaultFormValue = {
     accountType: ACCOUNT_TYPE_DEFAULT,
@@ -122,6 +133,7 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
     if (props.defaultLicense) {
       this.selectedLicense = props.defaultLicense;
     }
+    this.getAllCompanies();
   }
 
   @autobind
@@ -136,7 +148,8 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
       licenseType: this.selectedLicense,
       tokenIsRenewable: this.selectedAccountType !== AccountType.TRIAL,
       jobTitle: values.jobTitle,
-      company: values.companyName,
+      company: this.selectedCompanyOption?.value,
+      companyName: values.companyName,
       city: values.city,
       country: values.country,
     };
@@ -330,6 +343,28 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
     this.password = event.target.value;
   }
 
+  @action
+  getAllCompanies() {
+    client
+      .getAllCompaniesUsingGET({})
+      .then(
+        companies =>
+          (this.companyOptions = companies.map(company => ({
+            label: `${company.name} (${company.companyType})`,
+            value: company,
+          })))
+      )
+      .catch(error => notifyError(error));
+  }
+
+  @action.bound
+  onSelectCompany(selectedOption: CompanySelectOptionType) {
+    this.selectedCompanyOption = selectedOption;
+    if (selectedOption) {
+      this.onSelectLicense(selectedOption.value.licenseType as LicenseType);
+    }
+  }
+
   render() {
     return (
       <AvForm
@@ -498,119 +533,135 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                   </h5>
                 </Col>
                 <Col md="9">
-                  {this.selectedLicense !== LicenseType.ACADEMIC && (
-                    <p>
-                      Please feel free to skip this section if your{' '}
-                      {getAccountInfoTitle(
+                  <FormSelectWithLabelField
+                    onSelection={(selectedOption: CompanySelectOptionType) => {
+                      this.onSelectCompany(selectedOption);
+                    }}
+                    labelText={'Select a company to register a user under'}
+                    name={'companyDropdown'}
+                    options={this.companyOptions}
+                    isClearable={true}
+                    value={this.selectedCompanyOption}
+                  />
+                  <div className="border-top py-3">
+                    {this.selectedLicense !== LicenseType.ACADEMIC && (
+                      <p>
+                        Please feel free to skip this section if your{' '}
+                        {getAccountInfoTitle(
+                          ACCOUNT_TITLES.COMPANY,
+                          this.selectedLicense
+                        ).toLowerCase()}{' '}
+                        already has a license with us.
+                      </p>
+                    )}
+                    <AvField
+                      name="company"
+                      label={getAccountInfoTitle(
                         ACCOUNT_TITLES.COMPANY,
                         this.selectedLicense
-                      ).toLowerCase()}{' '}
-                      already has a license with us.
-                    </p>
-                  )}
-                  <AvField
-                    name="company"
-                    label={getAccountInfoTitle(
-                      ACCOUNT_TITLES.COMPANY,
-                      this.selectedLicense
-                    )}
-                    validate={{
-                      required: {
-                        value: true,
-                        errorMessage: 'Your organization name is required.',
-                      },
-                      ...this.textValidation,
-                    }}
-                  />
-                  <AvField
-                    name="city"
-                    label={getAccountInfoTitle(
-                      ACCOUNT_TITLES.CITY,
-                      this.selectedLicense
-                    )}
-                  />
-                  <AvField
-                    name="country"
-                    label={getAccountInfoTitle(
-                      ACCOUNT_TITLES.COUNTRY,
-                      this.selectedLicense
-                    )}
-                  />
-                  <AvField
-                    name={FormKey.COMPANY_DESCRIPTION}
-                    label={`${getAccountInfoTitle(
-                      ACCOUNT_TITLES.COMPANY,
-                      this.selectedLicense
-                    )} Description`}
-                    type={'textarea'}
-                    placeholder={this.companyDescriptionPlaceholder}
-                    rows={4}
-                  />
-                  {this.isCommercialLicense && (
-                    <>
-                      <AvField
-                        name={FormKey.BUS_CONTACT_EMAIL}
-                        label={'Business Contact Email'}
-                        type="email"
-                        validate={{
-                          ...this.emailValidation,
-                          required: {
-                            value: false,
-                          },
-                        }}
-                      />
-                      <AvField
-                        name={FormKey.BUS_CONTACT_PHONE}
-                        label={'Business Contact Phone Number'}
-                        type="tel"
-                      />
-                    </>
-                  )}
-                  <AvField
-                    name={FormKey.USE_CASE}
-                    label={'Describe how you plan to use OncoKB'}
-                    type={'textarea'}
-                    placeholder={this.useCasePlaceholder}
-                    rows={6}
-                    validate={{
-                      required: {
-                        value: true,
-                        errorMessage: 'Your use case is required.',
-                      },
-                      pattern: {
-                        value: XRegExp(XREGEXP_VALID_LATIN_TEXT),
-                        errorMessage:
-                          'Sorry, we only support Latin letters for now.',
-                      },
-                      minLength: {
-                        value: 1,
-                        errorMessage: 'Required to be at least 1 character',
-                      },
-                    }}
-                  />
-                  {[LicenseType.COMMERCIAL, LicenseType.HOSPITAL].includes(
-                    this.selectedLicense
-                  ) && (
+                      )}
+                      validate={{
+                        required: {
+                          value: true,
+                          errorMessage: 'Your organization name is required.',
+                        },
+                        ...this.textValidation,
+                      }}
+                      value={this.selectedCompanyOption?.value.name || ''}
+                    />
                     <AvField
-                      name={FormKey.ANTICIPATED_REPORTS}
-                      label={
-                        'Anticipated # of reports annually for years 1, 2 and 3'
-                      }
+                      name="city"
+                      label={getAccountInfoTitle(
+                        ACCOUNT_TITLES.CITY,
+                        this.selectedLicense
+                      )}
+                    />
+                    <AvField
+                      name="country"
+                      label={getAccountInfoTitle(
+                        ACCOUNT_TITLES.COUNTRY,
+                        this.selectedLicense
+                      )}
+                    />
+                    <AvField
+                      name={FormKey.COMPANY_DESCRIPTION}
+                      label={`${getAccountInfoTitle(
+                        ACCOUNT_TITLES.COMPANY,
+                        this.selectedLicense
+                      )} Description`}
                       type={'textarea'}
-                      placeholder={
-                        'If you plan to incorporate OncoKB contents in sequencing reports, please provide an estimate of your anticipated volume over the next several years'
+                      placeholder={this.companyDescriptionPlaceholder}
+                      rows={4}
+                      value={
+                        this.selectedCompanyOption?.value.description || ''
                       }
                     />
-                  )}
-                  {[LicenseType.RESEARCH_IN_COMMERCIAL].includes(
-                    this.selectedLicense
-                  ) && (
+                    {this.isCommercialLicense && (
+                      <>
+                        <AvField
+                          name={FormKey.BUS_CONTACT_EMAIL}
+                          label={'Business Contact Email'}
+                          type="email"
+                          validate={{
+                            ...this.emailValidation,
+                            required: {
+                              value: false,
+                            },
+                          }}
+                        />
+                        <AvField
+                          name={FormKey.BUS_CONTACT_PHONE}
+                          label={'Business Contact Phone Number'}
+                          type="tel"
+                        />
+                      </>
+                    )}
                     <AvField
-                      name={FormKey.COMPANY_SIZE}
-                      label={'Company Size (# of employees)'}
-                      type={'input'}
+                      name={FormKey.USE_CASE}
+                      label={'Describe how you plan to use OncoKB'}
+                      type={'textarea'}
+                      placeholder={this.useCasePlaceholder}
+                      rows={6}
+                      validate={{
+                        required: {
+                          value: true,
+                          errorMessage: 'Your use case is required.',
+                        },
+                        pattern: {
+                          value: XRegExp(XREGEXP_VALID_LATIN_TEXT),
+                          errorMessage:
+                            'Sorry, we only support Latin letters for now.',
+                        },
+                        minLength: {
+                          value: 1,
+                          errorMessage: 'Required to be at least 1 character',
+                        },
+                      }}
                     />
-                  )}
+                    {[LicenseType.COMMERCIAL, LicenseType.HOSPITAL].includes(
+                      this.selectedLicense
+                    ) && (
+                      <AvField
+                        name={FormKey.ANTICIPATED_REPORTS}
+                        label={
+                          'Anticipated # of reports annually for years 1, 2 and 3'
+                        }
+                        type={'textarea'}
+                        placeholder={
+                          'If you plan to incorporate OncoKB contents in sequencing reports, please provide an estimate of your anticipated volume over the next several years'
+                        }
+                      />
+                    )}
+                    {[LicenseType.RESEARCH_IN_COMMERCIAL].includes(
+                      this.selectedLicense
+                    ) && (
+                      <AvField
+                        name={FormKey.COMPANY_SIZE}
+                        label={'Company Size (# of employees)'}
+                        type={'input'}
+                      />
+                    )}
+                  </div>
                 </Col>
               </Row>
             )}
@@ -658,6 +709,7 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                         this.selectedAccountType = ACCOUNT_TYPE_DEFAULT;
                       }
                     }}
+                    disabled={this.selectedCompanyOption ? true : false}
                   >
                     <AvRadio
                       label={AccountType.REGULAR}

--- a/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
+++ b/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
@@ -164,9 +164,7 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
     }
     if (values.tokenValidDays) {
       newUser.tokenValidDays = Number(values.tokenValidDays);
-      newUser.notifyUserOnTrialCreation =
-        _.isArray(values.notifyUserOnTrialCreation) &&
-        values.notifyUserOnTrialCreation.length > 0;
+      newUser.notifyUserOnTrialCreation = true;
     }
     this.props.onSubmit(newUser);
   }
@@ -771,14 +769,10 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                           validate={{ number: true }}
                         />
                       </div>
-                      <div className={'mt-2'}>
-                        <AvCheckboxGroup name="notifyUserOnTrialCreation">
-                          <AvCheckbox
-                            label={'Send trial License agreement'}
-                            value={'true'}
-                          />
-                        </AvCheckboxGroup>
-                      </div>
+                      <span>
+                        A trial license agreement email will be sent to the
+                        user.
+                      </span>
                     </>
                   ) : null}
                 </Col>

--- a/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
+++ b/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
@@ -20,11 +20,12 @@ import {
 import {
   ACADEMIC_TERMS,
   ACCOUNT_TITLES,
+  LicenseStatus,
   LicenseType,
   THRESHOLD_TRIAL_TOKEN_VALID_DEFAULT,
   XREGEXP_VALID_LATIN_TEXT,
 } from 'app/config/constants';
-import { Button, Col, Row } from 'react-bootstrap';
+import { Alert, Button, Col, Row } from 'react-bootstrap';
 import LicenseExplanation from 'app/shared/texts/LicenseExplanation';
 import { ButtonSelections } from 'app/components/LicenseSelection';
 import { LicenseInquireLink } from 'app/shared/links/LicenseInquireLink';
@@ -38,6 +39,7 @@ import _ from 'lodash';
 import { FormSelectWithLabelField } from 'app/shared/select/FormSelectWithLabelField';
 import client from 'app/shared/api/clientInstance';
 import { notifyError } from 'app/shared/utils/NotificationUtils';
+import InfoIcon from 'app/shared/icons/InfoIcon';
 
 export enum FormSection {
   LICENSE = 'LICENSE',
@@ -76,6 +78,7 @@ export const ACCOUNT_TYPE_DEFAULT = AccountType.REGULAR;
 @observer
 export class NewAccountForm extends React.Component<INewAccountForm> {
   @observable password = '';
+  @observable email = '';
   @observable selectedLicense: LicenseType | undefined;
   @observable selectedAccountType = ACCOUNT_TYPE_DEFAULT;
   @observable companyOptions: CompanySelectOptionType[] = [];
@@ -149,7 +152,9 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
       tokenIsRenewable: this.selectedAccountType !== AccountType.TRIAL,
       jobTitle: values.jobTitle,
       company: this.selectedCompanyOption?.value,
-      companyName: values.companyName,
+      companyName: this.selectedCompanyOption
+        ? this.selectedCompanyOption.value.name
+        : values.companyName,
       city: values.city,
       country: values.country,
     };
@@ -360,9 +365,26 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
   @action.bound
   onSelectCompany(selectedOption: CompanySelectOptionType) {
     this.selectedCompanyOption = selectedOption;
+    this.selectedAccountType =
+      this.selectedCompanyOption.value.licenseStatus === LicenseStatus.TRIAL
+        ? AccountType.TRIAL
+        : AccountType.REGULAR;
     if (selectedOption) {
       this.onSelectLicense(selectedOption.value.licenseType as LicenseType);
     }
+  }
+
+  @computed
+  get showEmailMismatchConfirmation() {
+    const emailDomain = this.email.substring(
+      this.email.includes('@') ? this.email.indexOf('@') + 1 : this.email.length
+    );
+    const hasADomainMatch = this.selectedCompanyOption?.value.companyDomains.some(
+      domain => domain === emailDomain
+    );
+    return (
+      this.email.length > 5 && this.selectedCompanyOption && !hasADomainMatch
+    );
   }
 
   render() {
@@ -389,7 +411,14 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                   isLargeScreen={this.props.isLargeScreen}
                   selectedButton={this.selectedLicense}
                   onSelectLicense={this.onSelectLicense}
+                  disabled={!!this.selectedCompanyOption}
                 />
+                {!this.selectedCompanyOption ? null : (
+                  <span>
+                    User should have same license status as company. Unselect
+                    company to enable license selection.
+                  </span>
+                )}
               </Col>
             </Row>
           </>
@@ -459,8 +488,21 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                       this.selectedLicense
                     )}
                     type="email"
+                    value={this.email}
+                    onChange={(event: any) => {
+                      this.email = event.target.value;
+                    }}
                     validate={this.emailValidation}
                   />
+                  {this.showEmailMismatchConfirmation ? (
+                    <Alert variant={'warning'}>
+                      <i className={'mr-2 fa fa-exclamation-triangle'}></i>
+                      <span>
+                        The entered email address domain does not match any of
+                        the company's domains. Please confirm before proceeding.
+                      </span>
+                    </Alert>
+                  ) : null}
                   <If condition={!this.props.byAdmin}>
                     <Then>
                       <AvField
@@ -543,125 +585,123 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                     isClearable={true}
                     value={this.selectedCompanyOption}
                   />
-                  <div className="border-top py-3">
-                    {this.selectedLicense !== LicenseType.ACADEMIC && (
-                      <p>
-                        Please feel free to skip this section if your{' '}
-                        {getAccountInfoTitle(
+                  {this.selectedCompanyOption ? null : (
+                    <div className="border-top py-3">
+                      {this.selectedLicense !== LicenseType.ACADEMIC && (
+                        <p>
+                          Please feel free to skip this section if your{' '}
+                          {getAccountInfoTitle(
+                            ACCOUNT_TITLES.COMPANY,
+                            this.selectedLicense
+                          ).toLowerCase()}{' '}
+                          already has a license with us.
+                        </p>
+                      )}
+                      <AvField
+                        name="company"
+                        label={getAccountInfoTitle(
                           ACCOUNT_TITLES.COMPANY,
                           this.selectedLicense
-                        ).toLowerCase()}{' '}
-                        already has a license with us.
-                      </p>
-                    )}
-                    <AvField
-                      name="company"
-                      label={getAccountInfoTitle(
-                        ACCOUNT_TITLES.COMPANY,
-                        this.selectedLicense
-                      )}
-                      validate={{
-                        required: {
-                          value: true,
-                          errorMessage: 'Your organization name is required.',
-                        },
-                        ...this.textValidation,
-                      }}
-                      value={this.selectedCompanyOption?.value.name || ''}
-                    />
-                    <AvField
-                      name="city"
-                      label={getAccountInfoTitle(
-                        ACCOUNT_TITLES.CITY,
-                        this.selectedLicense
-                      )}
-                    />
-                    <AvField
-                      name="country"
-                      label={getAccountInfoTitle(
-                        ACCOUNT_TITLES.COUNTRY,
-                        this.selectedLicense
-                      )}
-                    />
-                    <AvField
-                      name={FormKey.COMPANY_DESCRIPTION}
-                      label={`${getAccountInfoTitle(
-                        ACCOUNT_TITLES.COMPANY,
-                        this.selectedLicense
-                      )} Description`}
-                      type={'textarea'}
-                      placeholder={this.companyDescriptionPlaceholder}
-                      rows={4}
-                      value={
-                        this.selectedCompanyOption?.value.description || ''
-                      }
-                    />
-                    {this.isCommercialLicense && (
-                      <>
-                        <AvField
-                          name={FormKey.BUS_CONTACT_EMAIL}
-                          label={'Business Contact Email'}
-                          type="email"
-                          validate={{
-                            ...this.emailValidation,
-                            required: {
-                              value: false,
-                            },
-                          }}
-                        />
-                        <AvField
-                          name={FormKey.BUS_CONTACT_PHONE}
-                          label={'Business Contact Phone Number'}
-                          type="tel"
-                        />
-                      </>
-                    )}
-                    <AvField
-                      name={FormKey.USE_CASE}
-                      label={'Describe how you plan to use OncoKB'}
-                      type={'textarea'}
-                      placeholder={this.useCasePlaceholder}
-                      rows={6}
-                      validate={{
-                        required: {
-                          value: true,
-                          errorMessage: 'Your use case is required.',
-                        },
-                        pattern: {
-                          value: XRegExp(XREGEXP_VALID_LATIN_TEXT),
-                          errorMessage:
-                            'Sorry, we only support Latin letters for now.',
-                        },
-                        minLength: {
-                          value: 1,
-                          errorMessage: 'Required to be at least 1 character',
-                        },
-                      }}
-                    />
-                    {[LicenseType.COMMERCIAL, LicenseType.HOSPITAL].includes(
-                      this.selectedLicense
-                    ) && (
+                        )}
+                        validate={{
+                          required: {
+                            value: true,
+                            errorMessage: 'Your organization name is required.',
+                          },
+                          ...this.textValidation,
+                        }}
+                      />
                       <AvField
-                        name={FormKey.ANTICIPATED_REPORTS}
-                        label={
-                          'Anticipated # of reports annually for years 1, 2 and 3'
-                        }
+                        name="city"
+                        label={getAccountInfoTitle(
+                          ACCOUNT_TITLES.CITY,
+                          this.selectedLicense
+                        )}
+                      />
+                      <AvField
+                        name="country"
+                        label={getAccountInfoTitle(
+                          ACCOUNT_TITLES.COUNTRY,
+                          this.selectedLicense
+                        )}
+                      />
+                      <AvField
+                        name={FormKey.COMPANY_DESCRIPTION}
+                        label={`${getAccountInfoTitle(
+                          ACCOUNT_TITLES.COMPANY,
+                          this.selectedLicense
+                        )} Description`}
                         type={'textarea'}
-                        placeholder={
-                          'If you plan to incorporate OncoKB contents in sequencing reports, please provide an estimate of your anticipated volume over the next several years'
-                        }
+                        placeholder={this.companyDescriptionPlaceholder}
+                        rows={4}
                       />
-                    )}
-                    {[LicenseType.RESEARCH_IN_COMMERCIAL].includes(
-                      this.selectedLicense
-                    ) && (
+                      {this.isCommercialLicense && (
+                        <>
+                          <AvField
+                            name={FormKey.BUS_CONTACT_EMAIL}
+                            label={'Business Contact Email'}
+                            type="email"
+                            validate={{
+                              ...this.emailValidation,
+                              required: {
+                                value: false,
+                              },
+                            }}
+                          />
+                          <AvField
+                            name={FormKey.BUS_CONTACT_PHONE}
+                            label={'Business Contact Phone Number'}
+                            type="tel"
+                          />
+                        </>
+                      )}
                       <AvField
-                        name={FormKey.COMPANY_SIZE}
-                        label={'Company Size (# of employees)'}
-                        type={'input'}
+                        name={FormKey.USE_CASE}
+                        label={'Describe how you plan to use OncoKB'}
+                        type={'textarea'}
+                        placeholder={this.useCasePlaceholder}
+                        rows={6}
+                        validate={{
+                          required: {
+                            value: true,
+                            errorMessage: 'Your use case is required.',
+                          },
+                          pattern: {
+                            value: XRegExp(XREGEXP_VALID_LATIN_TEXT),
+                            errorMessage:
+                              'Sorry, we only support Latin letters for now.',
+                          },
+                          minLength: {
+                            value: 1,
+                            errorMessage: 'Required to be at least 1 character',
+                          },
+                        }}
                       />
-                    )}
-                  </div>
+                      {[LicenseType.COMMERCIAL, LicenseType.HOSPITAL].includes(
+                        this.selectedLicense
+                      ) && (
+                        <AvField
+                          name={FormKey.ANTICIPATED_REPORTS}
+                          label={
+                            'Anticipated # of reports annually for years 1, 2 and 3'
+                          }
+                          type={'textarea'}
+                          placeholder={
+                            'If you plan to incorporate OncoKB contents in sequencing reports, please provide an estimate of your anticipated volume over the next several years'
+                          }
+                        />
+                      )}
+                      {[LicenseType.RESEARCH_IN_COMMERCIAL].includes(
+                        this.selectedLicense
+                      ) && (
+                        <AvField
+                          name={FormKey.COMPANY_SIZE}
+                          label={'Company Size (# of employees)'}
+                          type={'input'}
+                        />
+                      )}
+                    </div>
+                  )}
                 </Col>
               </Row>
             )}
@@ -709,6 +749,7 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                         this.selectedAccountType = ACCOUNT_TYPE_DEFAULT;
                       }
                     }}
+                    value={this.selectedAccountType}
                     disabled={this.selectedCompanyOption ? true : false}
                   >
                     <AvRadio

--- a/src/main/webapp/app/components/newCompanyForm/NewCompanyForm.tsx
+++ b/src/main/webapp/app/components/newCompanyForm/NewCompanyForm.tsx
@@ -77,7 +77,7 @@ export class NewCompanyForm extends React.Component<INewCompanyFormProps> {
   private debouncedLookup = _.debounce(
     (value: string, ctx, input, cb: (isValid: boolean | string) => void) => {
       client
-        .getCompanyByNameUsingGET({ name: value })
+        .getCompanyByNameUsingGET({ name: value.trim() })
         .then(company => cb('Company name in use!'))
         .catch(error => cb(true));
     },

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -155,6 +155,13 @@
             "schema": {
               "$ref": "#/definitions/KeyAndTermsVM"
             }
+          },
+          {
+            "name": "newAccountCreation",
+            "in": "query",
+            "description": "newAccountCreation",
+            "required": true,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -830,6 +830,45 @@
         "deprecated": false
       }
     },
+    "/api/companies/name/{name}": {
+      "get": {
+        "tags": [
+          "company-resource"
+        ],
+        "summary": "getCompanyByName",
+        "operationId": "getCompanyByNameUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/CompanyDTO"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
     "/api/companies/{id}": {
       "get": {
         "tags": [

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -155,13 +155,6 @@
             "schema": {
               "$ref": "#/definitions/KeyAndTermsVM"
             }
-          },
-          {
-            "name": "newAccountCreation",
-            "in": "query",
-            "description": "newAccountCreation",
-            "required": true,
-            "type": "boolean"
           }
         ],
         "responses": {

--- a/src/main/webapp/app/shared/api/generated/API.ts
+++ b/src/main/webapp/app/shared/api/generated/API.ts
@@ -1804,6 +1804,81 @@ export default class API {
             return response.body;
         });
     };
+    getCompanyByNameUsingGETURL(parameters: {
+        'name': string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/api/companies/name/{name}';
+
+        path = path.replace('{name}', parameters['name'] + '');
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * getCompanyByName
+     * @method
+     * @name API#getCompanyByNameUsingGET
+     * @param {string} name - name
+     */
+    getCompanyByNameUsingGETWithHttpInfo(parameters: {
+        'name': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/api/companies/name/{name}';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = '*/*';
+
+            path = path.replace('{name}', parameters['name'] + '');
+
+            if (parameters['name'] === undefined) {
+                reject(new Error('Missing required  parameter: name'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * getCompanyByName
+     * @method
+     * @name API#getCompanyByNameUsingGET
+     * @param {string} name - name
+     */
+    getCompanyByNameUsingGET(parameters: {
+        'name': string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < CompanyDTO > {
+        return this.getCompanyByNameUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
     getCompanyUsingGETURL(parameters: {
         'id': number,
         $queryParameters ? : any

--- a/src/main/webapp/app/shared/api/generated/API.ts
+++ b/src/main/webapp/app/shared/api/generated/API.ts
@@ -568,15 +568,10 @@ export default class API {
     };
     finishTrialAccountActivationUsingPOSTURL(parameters: {
         'keyAndTermsVm': KeyAndTermsVM,
-        'newAccountCreation': boolean,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
         let path = '/api/account/active-trial/finish';
-
-        if (parameters['newAccountCreation'] !== undefined) {
-            queryParameters['newAccountCreation'] = parameters['newAccountCreation'];
-        }
 
         if (parameters.$queryParameters) {
             Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
@@ -593,11 +588,9 @@ export default class API {
      * @method
      * @name API#finishTrialAccountActivationUsingPOST
      * @param {} keyAndTermsVm - keyAndTermsVM
-     * @param {boolean} newAccountCreation - newAccountCreation
      */
     finishTrialAccountActivationUsingPOSTWithHttpInfo(parameters: {
         'keyAndTermsVm': KeyAndTermsVM,
-        'newAccountCreation': boolean,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < request.Response > {
@@ -622,15 +615,6 @@ export default class API {
                 return;
             }
 
-            if (parameters['newAccountCreation'] !== undefined) {
-                queryParameters['newAccountCreation'] = parameters['newAccountCreation'];
-            }
-
-            if (parameters['newAccountCreation'] === undefined) {
-                reject(new Error('Missing required  parameter: newAccountCreation'));
-                return;
-            }
-
             if (parameters.$queryParameters) {
                 Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
                     var parameter = parameters.$queryParameters[parameterName];
@@ -648,11 +632,9 @@ export default class API {
      * @method
      * @name API#finishTrialAccountActivationUsingPOST
      * @param {} keyAndTermsVm - keyAndTermsVM
-     * @param {boolean} newAccountCreation - newAccountCreation
      */
     finishTrialAccountActivationUsingPOST(parameters: {
         'keyAndTermsVm': KeyAndTermsVM,
-        'newAccountCreation': boolean,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < UserDTO > {

--- a/src/main/webapp/app/shared/api/generated/API.ts
+++ b/src/main/webapp/app/shared/api/generated/API.ts
@@ -568,10 +568,15 @@ export default class API {
     };
     finishTrialAccountActivationUsingPOSTURL(parameters: {
         'keyAndTermsVm': KeyAndTermsVM,
+        'newAccountCreation': boolean,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
         let path = '/api/account/active-trial/finish';
+
+        if (parameters['newAccountCreation'] !== undefined) {
+            queryParameters['newAccountCreation'] = parameters['newAccountCreation'];
+        }
 
         if (parameters.$queryParameters) {
             Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
@@ -588,9 +593,11 @@ export default class API {
      * @method
      * @name API#finishTrialAccountActivationUsingPOST
      * @param {} keyAndTermsVm - keyAndTermsVM
+     * @param {boolean} newAccountCreation - newAccountCreation
      */
     finishTrialAccountActivationUsingPOSTWithHttpInfo(parameters: {
         'keyAndTermsVm': KeyAndTermsVM,
+        'newAccountCreation': boolean,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < request.Response > {
@@ -615,6 +622,15 @@ export default class API {
                 return;
             }
 
+            if (parameters['newAccountCreation'] !== undefined) {
+                queryParameters['newAccountCreation'] = parameters['newAccountCreation'];
+            }
+
+            if (parameters['newAccountCreation'] === undefined) {
+                reject(new Error('Missing required  parameter: newAccountCreation'));
+                return;
+            }
+
             if (parameters.$queryParameters) {
                 Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
                     var parameter = parameters.$queryParameters[parameterName];
@@ -632,9 +648,11 @@ export default class API {
      * @method
      * @name API#finishTrialAccountActivationUsingPOST
      * @param {} keyAndTermsVm - keyAndTermsVM
+     * @param {boolean} newAccountCreation - newAccountCreation
      */
     finishTrialAccountActivationUsingPOST(parameters: {
         'keyAndTermsVm': KeyAndTermsVM,
+        'newAccountCreation': boolean,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < UserDTO > {

--- a/src/main/webapp/app/shared/select/FormSelectWithLabelField.tsx
+++ b/src/main/webapp/app/shared/select/FormSelectWithLabelField.tsx
@@ -5,9 +5,11 @@ export type IFormSelectWithLabelProps = {
   onSelection: (selectedOption: any) => void;
   labelText: string;
   name: string;
-  defaultValue: { value: string; label: string };
-  options: { value: string; label: string }[];
+  defaultValue?: { value: any; label: any };
+  options: { value: any; label: any }[];
   boldLabel?: boolean;
+  isClearable?: boolean;
+  value?: { value: any; label: any } | null;
 };
 
 export const FormSelectWithLabelField: React.FunctionComponent<IFormSelectWithLabelProps> = props => {
@@ -24,6 +26,8 @@ export const FormSelectWithLabelField: React.FunctionComponent<IFormSelectWithLa
         defaultValue={props.defaultValue}
         options={props.options}
         onChange={props.onSelection}
+        isClearable={props.isClearable}
+        value={props.value}
       />
     </div>
   );


### PR DESCRIPTION
This fixes [issue #2770](https://github.com/oncokb/oncokb/issues/2770)
## Changes
#### Create Account Page
- Only admins will get a company dropdown. 
- When a user is created with a company selected, the user will automatically be linked to the company. 
- Company name and description will be automatically filled.

#### Create Company Page
- Companies cannot have the same name. 
- Add error message when user inputs a name that is already in use.
