### PR TITLE
Fix disabled endpoint

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/aop/api/APIConditionallyEnabledAspect.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/aop/api/APIConditionallyEnabledAspect.java
@@ -1,6 +1,6 @@
 package org.mskcc.cbio.oncokb.aop.api;
 
-import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.mskcc.cbio.oncokb.config.application.ApplicationProperties;
@@ -20,11 +20,13 @@ public class APIConditionallyEnabledAspect {
     }
 
     @Around("@annotation(APIConditionallyEnabled)")
-    public void apiConditionallyEnabled(JoinPoint jp, APIConditionallyEnabled APIConditionallyEnabled) throws Throwable {
+    public void apiConditionallyEnabled(ProceedingJoinPoint jp, APIConditionallyEnabled APIConditionallyEnabled) throws Throwable {
         // The logic for the disabled endpoint will not run when a method has the disableEndpoint annotation
         // and in readonly mode.
         if(this.applicationProperties.getDbReadOnly() == true){
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "This endpoint is disabled");
+        }else{
+            jp.proceed();
         }
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -316,8 +316,10 @@ public class AccountResource {
     public void requestPasswordReset(@RequestBody String mail) {
         Optional<User> user = userService.getUserWithAuthoritiesByEmailIgnoreCase(mail);
         if (user.isPresent()) {
-            userService.requestPasswordReset(user.get().getLogin());
-            mailService.sendPasswordResetMail(userMapper.userToUserDTO(user.get()));
+            Optional<User> updatedUser = userService.requestPasswordReset(user.get().getLogin());
+            if (updatedUser.isPresent()) {
+                mailService.sendPasswordResetMail(userMapper.userToUserDTO(updatedUser.get()));
+            }
         } else {
             // Pretend the request has been successful to prevent checking which emails really exist
             // but log that an invalid attempt has been made


### PR DESCRIPTION
Fix error from `disable-registration`
- When db-read-only is false, the method annotated with `APIConditionallyEnabled` was not executed
- Use the joinpoint.proceed() method to execute method when api endpoint is enabled.

Also fixes [issue #2849](https://github.com/oncokb/oncokb/issues/2849)
- Use updated user (one with the newly generated reset key) when sending email