### PR TITLE
Send approval email when regular user is automatically approved

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -176,6 +176,7 @@ public class AccountResource {
         if (company.getLicenseStatus().equals(LicenseStatus.REGULAR)) {
             userService.approveUser(userDTO, false);
             slackService.sendApprovedConfirmation(userDTO, company);
+            mailService.sendApprovalEmail(userDTO);
         }
         return true;
     }


### PR DESCRIPTION
This fixes issue: Users that were part of a regular, full licensed company were getting automatically approved and added to company, but did not receive an approval email.