### PR TITLE
Change logic for determining if user is on trial

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -291,8 +291,9 @@ public class UserService {
 
     public boolean trialAccountActivated(UserDTO userDTO) {
         List<Token> tokens = tokenService.findByUser(userMapper.userDTOToUser(userDTO));
-        return tokens.stream().filter(token -> !token.isRenewable()).findAny().isPresent();
+        return !tokens.stream().filter(token -> token.isRenewable()).findAny().isPresent();
     }
+
     public boolean trialAccountInitiated(UserDTO userDTO) {
         if (
             userDTO.getAdditionalInfo() == null
@@ -682,12 +683,11 @@ public class UserService {
     }
 
     private boolean userOnTrial(UserDTO userDTO) {
-        List<Token> tokens = tokenService.findByUser(userMapper.userDTOToUser(userDTO));
-        return tokens.stream()
-            .filter(token -> token.isRenewable().equals(false))
-            .map(token -> true)
+        return !tokenService.findByUser(userMapper.userDTOToUser(userDTO))
+            .stream()
+            .filter(token -> token.isRenewable())
             .findAny()
-            .orElse(false);
+            .isPresent();
 
     }
 

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -141,7 +141,7 @@ public class AccountResource {
             } else {
                 // This user exists before, we are looking for to extend the expiration date of all tokens associated
                 List<Token> userTokens = tokenService.findByUser(user);
-                boolean userAccountCanNOTBeExtended = userTokens.stream().filter(token -> !token.isRenewable()).findAny().isPresent();
+                boolean userAccountCanNOTBeExtended = !userTokens.stream().filter(token -> token.isRenewable()).findAny().isPresent();
                 if (userAccountCanNOTBeExtended) {
                     throw new AccountResourceException("Your account token is expired and cannot be extended.");
                 } else {

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
@@ -297,7 +297,10 @@ public class CronJobController {
         List<Token> tokens = tokenService
             .findAllExpiresBeforeDate(Instant.now().plusSeconds(DAY_IN_SECONDS * DAYS_TO_CHECK))
             .stream()
-            .filter(token -> !token.isRenewable() && token.getExpiration().isAfter(Instant.now()))
+            .filter(token -> 
+                // Do not include users that have atleast one renewable token because they are regular users
+                token.getExpiration().isAfter(Instant.now()) && !tokenService.findByUser(token.getUser()).stream().filter(t -> t.isRenewable()).findAny().isPresent()
+            )
             .filter(token -> {
                 // Do not include users that have been notified in the
                 return this.userMailsService.findUserMailsByUserAndMailTypeAndSentDateAfter(token.getUser(), TRIAL_ACCOUNT_IS_ABOUT_TO_EXPIRE, token.getExpiration().minusSeconds(DAY_IN_SECONDS * DAYS_TO_CHECK)).isEmpty();

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserUUIDController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserUUIDController.java
@@ -76,7 +76,7 @@ public class UserUUIDController {
             if (validTokens.size() > 0) {
                 uuid = validTokens.iterator().next().getToken();
             } else {
-                if (tokenList.stream().filter(token -> !token.isRenewable()).findAny().isPresent()) {
+                if (!tokenList.stream().filter(token -> token.isRenewable()).findAny().isPresent()) {
                     throw new TrialAccountExpiredException();
                 } else {
                     throw new TokenExpiredException();

--- a/src/main/webapp/app/pages/CreateCompanyUsersPage.tsx
+++ b/src/main/webapp/app/pages/CreateCompanyUsersPage.tsx
@@ -120,6 +120,8 @@ export class CreateCompanyUsersPage extends React.Component<
           this.company.result?.licenseStatus !== LicenseStatus.TRIAL,
         company: this.company.result,
         companyName: this.company.result?.name,
+        notifyUserOnTrialCreation:
+          this.company.result?.licenseStatus === LicenseStatus.TRIAL,
       } as ManagedUserVM;
     });
 

--- a/src/main/webapp/app/pages/userPage/UserPage.tsx
+++ b/src/main/webapp/app/pages/userPage/UserPage.tsx
@@ -100,9 +100,7 @@ export default class UserPage extends React.Component<IUserPage> {
       reaction(
         () => this.defaultSelectedAccountType,
         newDefault => {
-          if (this.selectedAccountType === undefined) {
-            this.selectedAccountType = newDefault;
-          }
+          this.selectedAccountType = newDefault;
         },
         true
       )
@@ -134,7 +132,7 @@ export default class UserPage extends React.Component<IUserPage> {
   @computed
   get defaultSelectedAccountType() {
     const currentlyIsTrialAccount =
-      this.userTokens.filter(token => !token.renewable).length > 0;
+      this.userTokens.filter(token => token.renewable).length < 1;
     return currentlyIsTrialAccount ? AccountType.TRIAL : AccountType.REGULAR;
   }
 

--- a/src/main/webapp/app/shared/table/UserTable.tsx
+++ b/src/main/webapp/app/shared/table/UserTable.tsx
@@ -97,17 +97,17 @@ export class UserTable extends React.Component<IUserTableProps> {
     if (this.props.licenseStatus === LicenseStatus.TRIAL) {
       if (
         this.props.usersTokens.some(
-          token => token.user.id === user.id && !token.renewable
+          token => token.user.id === user.id && token.renewable
         )
       ) {
-        status += ' (Trial)';
+        status += ' (Regular)';
       } else if (
         !user.additionalInfo?.trialAccount?.activation?.activationDate &&
         user.additionalInfo?.trialAccount?.activation?.key
       ) {
         status += ' (Pending)';
       } else {
-        status += ' (Regular)';
+        status += ' (Trial)';
       }
     }
     return status;

--- a/src/main/webapp/app/shared/table/UserTable.tsx
+++ b/src/main/webapp/app/shared/table/UserTable.tsx
@@ -96,16 +96,16 @@ export class UserTable extends React.Component<IUserTableProps> {
     let status = '';
     if (this.props.licenseStatus === LicenseStatus.TRIAL) {
       if (
+        !user.additionalInfo?.trialAccount?.activation?.activationDate &&
+        user.additionalInfo?.trialAccount?.activation?.key
+      ) {
+        status += ' (Pending)';
+      } else if (
         this.props.usersTokens.some(
           token => token.user.id === user.id && token.renewable
         )
       ) {
         status += ' (Regular)';
-      } else if (
-        !user.additionalInfo?.trialAccount?.activation?.activationDate &&
-        user.additionalInfo?.trialAccount?.activation?.key
-      ) {
-        status += ' (Pending)';
       } else {
         status += ' (Trial)';
       }

--- a/src/main/webapp/app/store/AuthenticationStore.ts
+++ b/src/main/webapp/app/store/AuthenticationStore.ts
@@ -177,7 +177,7 @@ class AuthenticationStore {
       token => new Date(token.expiration).getDate() <= Date.now()
     );
     const isTrialAccount =
-      this.tokens.filter(token => !token.renewable).length > 0;
+      this.tokens.filter(token => token.renewable).length < 1;
     if (tokenValid.length > 0) {
       const tokenAbout2Expire = this.tokens.filter(
         token =>


### PR DESCRIPTION
This fixes [issue #2858](https://github.com/oncokb/oncokb/issues/2858)

- Users with at least one renewable token are considered regular, not trial.
- Set `notifyUserOnTrialCreation` to true when creating users in the CreateCompanyUsersPage. Currently, it's only sending the account is created email.

