### PR TITLE
Wrap token_stats to s3

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/Constants.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/Constants.java
@@ -29,6 +29,11 @@ public final class Constants {
 
     public static final int TRIAL_PERIOD_IN_DAYS = 90;
 
+    public static final String USERS_USAGE_SUMMARY_FILE = "public-website/usage-analysis/userSummary.json";
+    public static final String RESOURCES_USAGE_SUMMARY_FILE = "public-website/usage-analysis/resourceSummary.json";
+    public static final String RESOURCES_USAGE_DETAIL_FILE = "public-website/usage-analysis/resourceDetail.json";
+    public static final String TOKEN_STATS_STORAGE_FILE_PREFIX = "public-website/token-usage/token-stats-";
+
     private Constants() {
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
@@ -143,7 +143,7 @@ public class TokenStats implements Serializable {
     }
 
     public String toCSV() {
-        return getId() +
+        return getToken().getUser().getEmail() +
             ";" + getAccessIp() +
             ";" + getResource() +
             ";" + getAccessTime() +
@@ -152,6 +152,7 @@ public class TokenStats implements Serializable {
     }
 
     public static String csvColumns() {
-        return "id;accessIp;resource;accessTime;tokenId;usageCount";
+        return "email;accessIp;resource;accessTime;tokenId;usageCount";
+
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.persistence.*;
 import javax.validation.constraints.*;
 
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.StringWriter;
 import java.time.Instant;
 
 /**
@@ -142,17 +144,23 @@ public class TokenStats implements Serializable {
             "}";
     }
 
-    public String toCSV() {
-        return getToken().getUser().getEmail() +
-            ";" + getAccessIp() +
-            ";" + getResource() +
-            ";" + getAccessTime() +
-            ";" + getUsageCount() +
-            ";" + getToken().getToken();
+    public String toTabDelimited() {
+        return String.format("%1$-50s\t%2$-15s\t%3$-20s\t%4$-10s\t%5$-36s\t%6$s",
+            getToken().getUser().getEmail(), // 50 char cutoff
+            getAccessIp(),
+            getAccessTime(),
+            getUsageCount(),
+            getToken().getToken(),
+            getResource());
     }
 
-    public static String csvHeaders() {
-        return "email;accessIp;resource;accessTime;usageCount;UUID";
-
+    public static String tabDelimitedHeaders() {
+        return String.format("%1$-50s\t%2$-12s\t%3$-20s\t%4$-10s\t%5$-36s\t%6$s",
+            "email",
+            "accessIp",
+            "accessTime",
+            "usageCount",
+            "UUID",
+            "resource");
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
@@ -141,4 +141,17 @@ public class TokenStats implements Serializable {
             ", usageCount=" + getUsageCount() +
             "}";
     }
+
+    public String toCSV() {
+        return getId() +
+            ";" + getAccessIp() +
+            ";" + getResource() +
+            ";" + getAccessTime() +
+            ";" + getUsageCount() +
+            ";" + getToken().getId();
+    }
+
+    public static String csvColumns() {
+        return "id;accessIp;resource;accessTime;tokenId;usageCount";
+    }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/domain/TokenStats.java
@@ -148,11 +148,11 @@ public class TokenStats implements Serializable {
             ";" + getResource() +
             ";" + getAccessTime() +
             ";" + getUsageCount() +
-            ";" + getToken().getId();
+            ";" + getToken().getToken();
     }
 
-    public static String csvColumns() {
-        return "email;accessIp;resource;accessTime;tokenId;usageCount";
+    public static String csvHeaders() {
+        return "email;accessIp;resource;accessTime;usageCount;UUID";
 
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -26,4 +26,6 @@ public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     " where tokenStats.accessTime > ?1 " +
     " group by tokenStats.token, DATE_FORMAT(tokenStats.accessTime,'%Y-%m'), tokenStats.resource", nativeQuery = true)
     List<UserTokenUsageWithInfo> countTokenUsageByTokenTimeResource(Instant after);
+
+    void deleteAll();
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -4,6 +4,8 @@ import org.mskcc.cbio.oncokb.domain.TokenStats;
 
 import org.mskcc.cbio.oncokb.querydomain.UserTokenUsage;
 import org.mskcc.cbio.oncokb.querydomain.UserTokenUsageWithInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
@@ -18,6 +20,10 @@ import java.util.List;
 public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     List<TokenStats> findByAccessTimeBefore(Instant before);
 
+    Page<TokenStats> findAllByAccessTimeBefore(Instant before, Pageable pageable);
+
+    void deleteAllByAccessTimeBefore(Instant before);
+
     @Query("select sum(tokenStats.usageCount) as count, tokenStats.token as token from TokenStats tokenStats where tokenStats.accessTime < ?1 group by tokenStats.token")
     List<UserTokenUsage> countTokenUsageByToken(Instant before);
 
@@ -26,6 +32,4 @@ public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     " where tokenStats.accessTime > ?1 " +
     " group by tokenStats.token, DATE_FORMAT(tokenStats.accessTime,'%Y-%m'), tokenStats.resource", nativeQuery = true)
     List<UserTokenUsageWithInfo> countTokenUsageByTokenTimeResource(Instant after);
-
-    void deleteAll();
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -18,8 +18,6 @@ import java.util.List;
 @SuppressWarnings("unused")
 @Repository
 public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
-    List<TokenStats> findByAccessTimeBefore(Instant before);
-
     Page<TokenStats> findAllByAccessTimeBefore(Instant before, Pageable pageable);
 
     void deleteAllByAccessTimeBefore(Instant before);

--- a/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
@@ -44,7 +44,7 @@ public interface TokenStatsService {
      */
     void delete(Long id);
 
-    void clearTokenStats();
+    void clearTokenStats(Instant before);
 
     void removeOldTokenStats();
 

--- a/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
@@ -44,6 +44,8 @@ public interface TokenStatsService {
      */
     void delete(Long id);
 
+    void clearTokenStats();
+
     void removeOldTokenStats();
 
     List<UserTokenUsage> getUserTokenUsage(Instant before);

--- a/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/TokenStatsService.java
@@ -3,6 +3,8 @@ package org.mskcc.cbio.oncokb.service;
 import org.mskcc.cbio.oncokb.domain.TokenStats;
 import org.mskcc.cbio.oncokb.querydomain.UserTokenUsage;
 import org.mskcc.cbio.oncokb.querydomain.UserTokenUsageWithInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 import java.util.List;
@@ -25,8 +27,9 @@ public interface TokenStatsService {
      * Get all the tokenStats.
      *
      * @return the list of entities.
+     * @param before
      */
-    List<TokenStats> findAll();
+    Page<TokenStats> findAll(Instant before, Pageable pageable);
 
 
     /**
@@ -45,8 +48,6 @@ public interface TokenStatsService {
     void delete(Long id);
 
     void clearTokenStats(Instant before);
-
-    void removeOldTokenStats();
 
     List<UserTokenUsage> getUserTokenUsage(Instant before);
 

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
@@ -62,6 +62,10 @@ public class TokenStatsServiceImpl implements TokenStatsService {
         tokenStatsRepository.deleteById(id);
     }
 
+    public void clearTokenStats() {
+        tokenStatsRepository.deleteAll();
+    }
+
     /**
      * Old audit events should be automatically deleted after 30 days.
      *

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
@@ -62,8 +62,8 @@ public class TokenStatsServiceImpl implements TokenStatsService {
         tokenStatsRepository.deleteById(id);
     }
 
-    public void clearTokenStats() {
-        tokenStatsRepository.deleteAll();
+    public void clearTokenStats(Instant before) {
+        tokenStatsRepository.deleteAllByAccessTimeBefore(before);
     }
 
     /**
@@ -83,7 +83,7 @@ public class TokenStatsServiceImpl implements TokenStatsService {
         return tokenStatsRepository.countTokenUsageByToken(before);
     }
 
-    public List<UserTokenUsageWithInfo> getTokenUsageAnalysis(Instant after){
+    public List<UserTokenUsageWithInfo> getTokenUsageAnalysis(Instant after) {
         return tokenStatsRepository.countTokenUsageByTokenTimeResource(after);
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/TokenStatsServiceImpl.java
@@ -9,11 +9,12 @@ import org.mskcc.cbio.oncokb.repository.TokenStatsRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,11 +42,10 @@ public class TokenStatsServiceImpl implements TokenStatsService {
         return tokenStatsRepository.save(tokenStats);
     }
 
-    @Override
     @Transactional(readOnly = true)
-    public List<TokenStats> findAll() {
+    public Page<TokenStats> findAll(Instant before, Pageable pageable) {
         log.debug("Request to get all TokenStats");
-        return tokenStatsRepository.findAll();
+        return tokenStatsRepository.findAllByAccessTimeBefore(before, pageable);
     }
 
 
@@ -63,20 +63,8 @@ public class TokenStatsServiceImpl implements TokenStatsService {
     }
 
     public void clearTokenStats(Instant before) {
+        log.info("Deleting old TokenStats");
         tokenStatsRepository.deleteAllByAccessTimeBefore(before);
-    }
-
-    /**
-     * Old audit events should be automatically deleted after 30 days.
-     *
-     */
-    public void removeOldTokenStats() {
-        tokenStatsRepository
-            .findByAccessTimeBefore(Instant.now().minus(jHipsterProperties.getAuditEvents().getRetentionPeriod(), ChronoUnit.DAYS))
-            .forEach(tokenStat -> {
-                log.debug("Deleting token stats", tokenStat);
-                tokenStatsRepository.delete(tokenStat);
-            });
     }
 
     public List<UserTokenUsage> getUserTokenUsage(Instant before) {

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
@@ -40,8 +40,7 @@ import org.json.simple.JSONObject;
 
 import org.kohsuke.github.*;
 
-import static org.mskcc.cbio.oncokb.config.Constants.DAY_IN_SECONDS;
-import static org.mskcc.cbio.oncokb.config.Constants.HALF_YEAR_IN_SECONDS;
+import static org.mskcc.cbio.oncokb.config.Constants.*;
 import static org.mskcc.cbio.oncokb.domain.enumeration.MailType.TRIAL_ACCOUNT_IS_ABOUT_TO_EXPIRE;
 import static org.mskcc.cbio.oncokb.domain.enumeration.MailType.VERIFY_EMAIL_BEFORE_ACCOUNT_EXPIRES;
 
@@ -78,11 +77,6 @@ public class CronJobController {
     private final AuditEventService auditEventService;
 
     private final ApplicationProperties applicationProperties;
-
-    final String USERS_USAGE_SUMMARY_FILE = "public-website/usage-analysis/userSummary.json";
-    final String RESOURCES_USAGE_SUMMARY_FILE = "public-website/usage-analysis/resourceSummary.json";
-    final String RESOURCES_USAGE_DETAIL_FILE = "public-website/usage-analysis/resourceDetail.json";
-    final String TOKEN_STATS_STORAGE_FILE_PREFIX = "public-website/token-usage/token-stats-";
 
     public CronJobController(UserService userService,
                              MailService mailService, TokenProvider tokenProvider,

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CronJobController.java
@@ -176,24 +176,6 @@ public class CronJobController {
     }
 
     /**
-     * {@code GET  /update-token-stats} : Update token stats.
-     */
-    @GetMapping(path = "/update-token-stats")
-    public void updateTokenStats() {
-        log.info("Started the cronjob to update token stats");
-        List<UserTokenUsage> tokenUsages = tokenStatsService.getUserTokenUsage(Instant.now());
-
-        // Update tokens with token usage
-        tokenUsages.stream().forEach(tokenUsage -> {
-                Optional<Token> tokenOptional = tokenService.findByToken(tokenUsage.getToken().getToken());
-                if (tokenOptional.isPresent()) {
-                    tokenOptional.get().setCurrentUsage(tokenOptional.get().getCurrentUsage() + tokenUsage.getCount());
-                    tokenService.save(tokenOptional.get());
-                }
-        });
-    }
-
-    /**
      * {@code GET /user-usage-analysis}: Analyze user usage
      *
      * @throws IOException
@@ -438,6 +420,20 @@ public class CronJobController {
     private void renewToken(Token token) {
         token.setExpiration(token.getExpiration().plusSeconds(tokenProvider.EXPIRATION_TIME_IN_SECONDS));
         tokenService.save(token);
+    }
+
+    private void updateTokenStats() {
+        log.info("Started the cronjob to update token stats");
+        List<UserTokenUsage> tokenUsages = tokenStatsService.getUserTokenUsage(Instant.now());
+
+        // Update tokens with token usage
+        tokenUsages.stream().forEach(tokenUsage -> {
+            Optional<Token> tokenOptional = tokenService.findByToken(tokenUsage.getToken().getToken());
+            if (tokenOptional.isPresent()) {
+                tokenOptional.get().setCurrentUsage(tokenOptional.get().getCurrentUsage() + tokenUsage.getCount());
+                tokenService.save(tokenOptional.get());
+            }
+        });
     }
 
     private File createWrappedFile() throws IOException {

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/TokenStatsResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/TokenStatsResource.java
@@ -80,23 +80,6 @@ public class TokenStatsResource {
     }
 
     /**
-     * {@code GET  /token-stats} : get all the tokenStats.
-     *
-     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of tokenStats in body.
-     */
-    @GetMapping("/token-stats")
-    public List<TokenStats> getAllTokenStats() {
-        log.debug("REST request to get all TokenStats");
-        int PAGE_SIZE = 1000;
-        Instant current = Instant.now();
-        List<TokenStats> tokenStatsList = new ArrayList<>();
-        for (int page = 0; page < tokenStatsService.findAll(current, PageRequest.of(0, PAGE_SIZE)).getTotalPages(); page++) {
-            tokenStatsList.addAll(tokenStatsService.findAll(current, PageRequest.of(page, PAGE_SIZE)).getContent());
-        }
-        return tokenStatsList;
-    }
-
-    /**
      * {@code GET  /token-stats/:id} : get the "id" tokenStats.
      *
      * @param id the id of the tokenStats to retrieve.

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/TokenStatsResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/TokenStatsResource.java
@@ -8,12 +8,16 @@ import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -83,7 +87,13 @@ public class TokenStatsResource {
     @GetMapping("/token-stats")
     public List<TokenStats> getAllTokenStats() {
         log.debug("REST request to get all TokenStats");
-        return tokenStatsService.findAll();
+        int PAGE_SIZE = 1000;
+        Instant current = Instant.now();
+        List<TokenStats> tokenStatsList = new ArrayList<>();
+        for (int page = 0; page < tokenStatsService.findAll(current, PageRequest.of(0, PAGE_SIZE)).getTotalPages(); page++) {
+            tokenStatsList.addAll(tokenStatsService.findAll(current, PageRequest.of(page, PAGE_SIZE)).getContent());
+        }
+        return tokenStatsList;
     }
 
     /**

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/UsageAnalysisController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/UsageAnalysisController.java
@@ -28,15 +28,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import static org.mskcc.cbio.oncokb.config.Constants.*;
+
 @Controller
 @RequestMapping("/api")
 public class UsageAnalysisController {
     @Autowired
     private S3Service s3Service;
-
-    final String USERS_USAGE_SUMMARY_FILE = "usage-analysis/userSummary.json";
-    final String RESOURCES_USAGE_SUMMARY_FILE = "usage-analysis/resourceSummary.json";
-    final String RESOURCES_DETAIL_SUMMARY_FILE = "usage-analysis/resourceDetail.json";
 
     private JSONObject requestData(String file)
             throws UnsupportedEncodingException, IOException, ParseException {
@@ -161,7 +159,7 @@ public class UsageAnalysisController {
             throws UnsupportedEncodingException, IOException, ParseException {
         HttpStatus status = HttpStatus.OK;
 
-        JSONObject jsonObject = requestData(RESOURCES_DETAIL_SUMMARY_FILE);
+        JSONObject jsonObject = requestData(RESOURCES_USAGE_DETAIL_FILE);
         if (jsonObject.containsKey(endpoint)){
             JSONObject usageObject = (JSONObject)jsonObject.get(endpoint);
             Gson gson = new Gson();

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -1528,6 +1528,33 @@
         "deprecated": false
       }
     },
+    "/api/cronjob/wrap-token-stats": {
+      "delete": {
+        "tags": [
+          "cron-job-controller"
+        ],
+        "summary": "wrapTokenStats",
+        "operationId": "wrapTokenStatsUsingDELETE",
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
     "/api/mails/feedback": {
       "post": {
         "tags": [

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -1474,13 +1474,14 @@
         "deprecated": false
       }
     },
-    "/api/cronjob/wrap-token-stats": {
-      "delete": {
+    "/api/cronjob/move-token-stats-to-s3": {
+      "get": {
         "tags": [
           "cron-job-controller"
         ],
-        "summary": "wrapTokenStats",
-        "operationId": "wrapTokenStatsUsingDELETE",
+        "summary": "moveTokenStatsToS3",
+        "operationId": "moveTokenStatsToS3UsingGET",
+        
         "produces": [
           "*/*"
         ],

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -1420,33 +1420,6 @@
         "deprecated": false
       }
     },
-    "/api/cronjob/remove-old-token-stats": {
-      "get": {
-        "tags": [
-          "cron-job-controller"
-        ],
-        "summary": "removeOldTokenStats",
-        "operationId": "removeOldTokenStatsUsingGET",
-        "produces": [
-          "*/*"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        },
-        "deprecated": false
-      }
-    },
     "/api/cronjob/renew-tokens": {
       "get": {
         "tags": [

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -1474,33 +1474,6 @@
         "deprecated": false
       }
     },
-    "/api/cronjob/update-token-stats": {
-      "get": {
-        "tags": [
-          "cron-job-controller"
-        ],
-        "summary": "updateTokenStats",
-        "operationId": "updateTokenStatsUsingGET",
-        "produces": [
-          "*/*"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        },
-        "deprecated": false
-      }
-    },
     "/api/cronjob/user-usage-analysis": {
       "get": {
         "tags": [


### PR DESCRIPTION
### **Token usage will now be stored in the oncokb s3 bucket**

Added cronjob to 
- retrieve token_stats SQL data
- parse data to txt file
- send file to `oncokb/token-usage/`
- clear token_stats table in the database

This is related to https://github.com/oncokb/oncokb/issues/2635