### PR TITLE
Fix company name validator

### DIFF
--- a/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
+++ b/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
@@ -358,7 +358,7 @@ export default class CompanyPage extends React.Component<
                                 input: any,
                                 cb: (isValid: boolean | string) => void
                               ) => {
-                                if (this.company.name !== value)
+                                if (this.company.name !== value) {
                                   debouncedCompanyNameValidator(
                                     value,
                                     ctx,
@@ -366,6 +366,9 @@ export default class CompanyPage extends React.Component<
                                     cb,
                                     this.company.id
                                   );
+                                } else {
+                                  cb(true);
+                                }
                               },
                             }}
                           />


### PR DESCRIPTION
This is a bug introduced (in [PR](https://github.com/oncokb/oncokb-public/pull/795/files)) when the company name validation function was modified to only run the check when the company name has changed. The `cb` function needs to be called for when the company name has not changed.
