### PR TITLE
Remove headers created with HeaderUtil

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CompanyDomainResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CompanyDomainResource.java
@@ -4,7 +4,6 @@ import org.mskcc.cbio.oncokb.service.CompanyDomainService;
 import org.mskcc.cbio.oncokb.web.rest.errors.BadRequestAlertException;
 import org.mskcc.cbio.oncokb.service.dto.CompanyDomainDTO;
 
-import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,9 +52,7 @@ public class CompanyDomainResource {
             throw new BadRequestAlertException("A new companyDomain cannot already have an ID", ENTITY_NAME, "idexists");
         }
         CompanyDomainDTO result = companyDomainService.save(companyDomainDTO);
-        return ResponseEntity.created(new URI("/api/company-domains/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, false, ENTITY_NAME, result.getId().toString()))
-            .body(result);
+        return ResponseEntity.created(new URI("/api/company-domains/" + result.getId())).body(result);
     }
 
     /**
@@ -74,9 +71,7 @@ public class CompanyDomainResource {
             throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
         }
         CompanyDomainDTO result = companyDomainService.save(companyDomainDTO);
-        return ResponseEntity.ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, false, ENTITY_NAME, companyDomainDTO.getId().toString()))
-            .body(result);
+        return ResponseEntity.ok().body(result);
     }
 
     /**
@@ -120,6 +115,6 @@ public class CompanyDomainResource {
     public ResponseEntity<Void> deleteCompanyDomain(@PathVariable Long id) {
         log.debug("REST request to delete CompanyDomain : {}", id);
         companyDomainService.delete(id);
-        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, false, ENTITY_NAME, id.toString())).build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CompanyResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CompanyResource.java
@@ -10,7 +10,6 @@ import org.mskcc.cbio.oncokb.web.rest.vm.VerifyCompanyNameVM;
 import org.mskcc.cbio.oncokb.service.dto.CompanyDTO;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 
-import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserDetailsResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserDetailsResource.java
@@ -5,7 +5,6 @@ import org.mskcc.cbio.oncokb.service.UserDetailsService;
 import org.mskcc.cbio.oncokb.web.rest.errors.BadRequestAlertException;
 import org.mskcc.cbio.oncokb.service.dto.UserDetailsDTO;
 
-import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,9 +52,7 @@ public class UserDetailsResource {
             throw new BadRequestAlertException("A new userDetails cannot already have an ID", ENTITY_NAME, "idexists");
         }
         UserDetailsDTO result = userDetailsService.save(userDetailsDTO);
-        return ResponseEntity.created(new URI("/api/user-details/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, false, ENTITY_NAME, result.getId().toString()))
-            .body(result);
+        return ResponseEntity.created(new URI("/api/user-details/" + result.getId())).body(result);
     }
 
     /**
@@ -74,9 +71,7 @@ public class UserDetailsResource {
             throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
         }
         UserDetailsDTO result = userDetailsService.save(userDetailsDTO);
-        return ResponseEntity.ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, false, ENTITY_NAME, userDetailsDTO.getId().toString()))
-            .body(result);
+        return ResponseEntity.ok().body(result);
     }
 
     /**
@@ -114,6 +109,6 @@ public class UserDetailsResource {
     public ResponseEntity<Void> deleteUserDetails(@PathVariable Long id) {
         log.debug("REST request to delete UserDetails : {}", id);
         userDetailsService.delete(id);
-        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, false, ENTITY_NAME, id.toString())).build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserMailsResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserMailsResource.java
@@ -6,7 +6,6 @@ import org.mskcc.cbio.oncokb.service.UserMailsService;
 import org.mskcc.cbio.oncokb.service.UserService;
 import org.mskcc.cbio.oncokb.service.dto.UserMailsDTO;
 
-import io.github.jhipster.web.util.HeaderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -79,6 +78,6 @@ public class UserMailsResource {
     public ResponseEntity<Void> deleteUserMails(@PathVariable Long id) {
         log.debug("REST request to delete UserMails : {}", id);
         userMailsService.delete(id);
-        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, false, ENTITY_NAME, id.toString())).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/errors/ExceptionTranslator.java
@@ -1,7 +1,6 @@
 package org.mskcc.cbio.oncokb.web.rest.errors;
 
 import io.github.jhipster.config.JHipsterConstants;
-import io.github.jhipster.web.util.HeaderUtil;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/errors/ExceptionTranslator.java
@@ -110,13 +110,13 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
     @ExceptionHandler
     public ResponseEntity<Problem> handleEmailAlreadyUsedException(org.mskcc.cbio.oncokb.service.EmailAlreadyUsedException ex, NativeWebRequest request) {
         EmailAlreadyUsedException problem = new EmailAlreadyUsedException();
-        return create(problem, request, HeaderUtil.createFailureAlert(applicationName,  false, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
+        return create(problem, request);
     }
 
     @ExceptionHandler
     public ResponseEntity<Problem> handleUsernameAlreadyUsedException(org.mskcc.cbio.oncokb.service.UsernameAlreadyUsedException ex, NativeWebRequest request) {
         LoginAlreadyUsedException problem = new LoginAlreadyUsedException();
-        return create(problem, request, HeaderUtil.createFailureAlert(applicationName,  false, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
+        return create(problem, request);
     }
 
     @ExceptionHandler
@@ -126,7 +126,7 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
 
     @ExceptionHandler
     public ResponseEntity<Problem> handleBadRequestAlertException(BadRequestAlertException ex, NativeWebRequest request) {
-        return create(ex, request, HeaderUtil.createFailureAlert(applicationName, false, ex.getEntityName(), ex.getErrorKey(), ex.getMessage()));
+        return create(ex, request);
     }
 
     @ExceptionHandler


### PR DESCRIPTION
This addresses [issue 2904](https://github.com/oncokb/oncokb/issues/2904) and [issue 2880](https://github.com/oncokb/oncokb/issues/2880)
Both issues were related to the error message shown when a user was already registered.

- Used the solution from [pr](https://github.com/oncokb/oncokb-public/pull/754)
- When the `LoginAlreadyUsedException` or `EmailAlreadyUsedException` are caught in ExceptionTranslator.java, we used HeaderUtil from jhipster to create a header, which adds headers starting with 'X-'