### PR TITLE
Remove approval email for auto approved user

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -176,7 +176,6 @@ public class AccountResource {
         if (company.getLicenseStatus().equals(LicenseStatus.REGULAR)) {
             userService.approveUser(userDTO, false);
             slackService.sendApprovedConfirmation(userDTO, company);
-            mailService.sendApprovalEmail(userDTO);
         }
         return true;
     }


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb/issues/2871

- Revert the change made in https://github.com/oncokb/oncokb-public/pull/789
- Auto-approved users will get an approval message on the website after they activate their account, so no need to send an email.