### PR TITLE
Update company trial user's expiration date

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -503,7 +503,7 @@ public class UserService {
                 tokens.forEach(token -> {
                     boolean wasRenewable = token.isRenewable();
                     Instant expirationDate = Instant.now().plusSeconds(DAY_IN_SECONDS * TRIAL_PERIOD_IN_DAYS);
-                    if (wasRenewable && token.getExpiration().isAfter(expirationDate)) {
+                    if (!wasRenewable && token.getExpiration().isAfter(expirationDate)) {
                         // We have some users that have a longer trial period
                         // Use the default trial period (90 days) or the non-renewable token's period, whichever is longer
                         expirationDate = token.getExpiration();

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -499,10 +499,17 @@ public class UserService {
                     isTrial ? Optional.of(TRIAL_PERIOD_IN_DAYS) : Optional.empty(),
                     isTrial ? Optional.of(false) : Optional.empty()
                 );
-            if(isTrial){
+            if (isTrial) {
                 tokens.forEach(token -> {
+                    boolean wasRenewable = token.isRenewable();
+                    Instant expirationDate = Instant.now().plusSeconds(DAY_IN_SECONDS * TRIAL_PERIOD_IN_DAYS);
+                    if (wasRenewable && token.getExpiration().isAfter(expirationDate)) {
+                        // We have some users that have a longer trial period
+                        // Use the default trial period (90 days) or the non-renewable token's period, whichever is longer
+                        expirationDate = token.getExpiration();
+                    }
                     token.setRenewable(false);
-                    token.setExpiration(Instant.now().plusSeconds(DAY_IN_SECONDS * TRIAL_PERIOD_IN_DAYS));
+                    token.setExpiration(expirationDate);
                     tokenService.save(token);
                 });
             }


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2902

When trial users are added to a trial company, then their tokens expiration date will be the longest of the default trial period (90 days) or their current token's expiration date.