### PR TITLE
Pass hash parameters from ApiAccessPageNavTab to pages

### DIFF
--- a/src/main/webapp/app/pages/apiAccessGroup/ApiAccessPageNavTab.tsx
+++ b/src/main/webapp/app/pages/apiAccessGroup/ApiAccessPageNavTab.tsx
@@ -47,6 +47,7 @@ export class ApiAccessPageNavTab extends React.Component<
       newSelectedTab => {
         this.props.routing.history.push({
           pathname: newSelectedTab as any,
+          hash: this.props.routing.location.hash,
         });
       }
     ),


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2906

When redirecting to `/account/register`, the hash parameters were not passed along. 
Adding the `hash` field in the location object fixes this issue.