### PR TITLE
Fix appStore undefined in OncoKBSearch

### DIFF
--- a/src/main/webapp/app/components/oncokbSearch/OncoKBSearch.tsx
+++ b/src/main/webapp/app/components/oncokbSearch/OncoKBSearch.tsx
@@ -91,7 +91,7 @@ export default class OncoKBSearch extends React.Component<IOncoKBSearch, {}> {
               search={this.keyword}
               type={props.data.queryType as SearchOptionType}
               data={props.data}
-              appStore={props.appStore}
+              appStore={this.props.appStore!}
             >
               <components.Option {...props} />
             </SearchOption>

--- a/src/main/webapp/app/components/searchOption/SearchOption.tsx
+++ b/src/main/webapp/app/components/searchOption/SearchOption.tsx
@@ -122,6 +122,9 @@ const AlterationSearchOption: React.FunctionComponent<{
             <FeedbackIcon
               feedback={{
                 type: FeedbackType.ANNOTATION,
+                annotation: {
+                  gene: props.search,
+                },
               }}
               appStore={props.appStore}
             />


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2923

- The `appStore` prop was passed incorrectly to `SearchOption` component, so it was undefined.
- Passed the search string to feedback so it is displayed in the modal title
   - Title was: `Annotation suggestion for [missing]` 