### PR TITLE
Don't generate token for inactivated users

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -403,7 +403,7 @@ public class UserService {
                 return newUserDTO;
             });
 
-        if (updatedUserDTO.isPresent()) {
+        if (updatedUserDTO.isPresent() && updatedUserDTO.get().isActivated()) {
             generateTokenForUserIfNotExist(updatedUserDTO.get(), Optional.empty(), Optional.empty());
         }
         return updatedUserDTO;

--- a/src/main/webapp/app/pages/userPage/UserPage.tsx
+++ b/src/main/webapp/app/pages/userPage/UserPage.tsx
@@ -132,6 +132,7 @@ export default class UserPage extends React.Component<IUserPage> {
   @computed
   get defaultSelectedAccountType() {
     const currentlyIsTrialAccount =
+      this.userTokens.length > 0 &&
       this.userTokens.filter(token => token.renewable).length < 1;
     return currentlyIsTrialAccount ? AccountType.TRIAL : AccountType.REGULAR;
   }
@@ -221,6 +222,7 @@ export default class UserPage extends React.Component<IUserPage> {
               })
               .then(
                 tokens => {
+                  this.userTokens = tokens;
                   tokens.forEach(token => {
                     if (
                       token.renewable !== tokenIsRenewable ||


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2960

- Check activation status before updating and also in UserPage default to `Regular` account type if user doesn't have any tokens.
   - We need `generateTokenForUserIfNotExists` in updateUser because we can activate user in UserPage and the user table.
- Also, when admin sets an inactivated user to activated in UserPage, the `this.userTokens` is not updated so token does not show up.