### PR TITLE
Include user login in activation email

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -148,6 +148,10 @@ public class UserService {
         return userRepository.findOneByActivationKey(key);
     }
 
+    public Optional<User> getUserByLogin(String login) {
+        return userRepository.findOneByLogin(login.toLowerCase());
+    }
+
     public Optional<User> completePasswordReset(String newPassword, String key) {
         log.debug("Reset user password for reset key {}", key);
         return userRepository.findOneByResetKey(key)

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -110,11 +110,14 @@ public class AccountResource {
      * @throws RuntimeException {@code 500 (Internal Server Error)} if the user couldn't be activated.
      */
     @GetMapping("/activate")
-    public boolean activateAccount(@RequestParam(value = "key") String key) {
-        Optional<User> userOptional = userService.getUserByActivationKey(key);
-        if (!userOptional.isPresent()) {
+    public boolean activateAccount(@RequestParam(value = "key") String key, @RequestParam(value = "login") String login) {
+        Optional<User> userOptional = userService.getUserByLogin(login);
+        if (!userOptional.isPresent() || (userOptional.get().getActivationKey() != null && !userOptional.get().getActivationKey().equals(key))) {
             throw new CustomMessageRuntimeException("Your user account could not be activated as no user was found associated with this activation key.");
         } else {
+            if(userOptional.get().getActivationKey() == null) {
+                return userOptional.get().getActivated();
+            }
             boolean newUserActivation = !userOptional.get().getActivated();
             userOptional = userService.activateRegistration(key);
 

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -118,6 +118,7 @@ public class AccountResource {
             if(userOptional.get().getActivationKey() == null) {
                 return userOptional.get().getActivated();
             }
+
             boolean newUserActivation = !userOptional.get().getActivated();
             userOptional = userService.activateRegistration(key);
 

--- a/src/main/resources/templates/mail/activationEmail.html
+++ b/src/main/resources/templates/mail/activationEmail.html
@@ -13,7 +13,7 @@
             Your OncoKB account has been created. Please click the URL below to verify your email address:
         </p>
         <p>
-            <a th:with="url=(@{|${baseUrl}/account/verify?key=${user.activationKey}|})" th:href="${url}"
+            <a th:with="url=(@{|${baseUrl}/account/verify?key=${user.activationKey}&login=${user.login}|})" th:href="${url}"
             th:text="${url}">Verification link</a>
         </p>
         <p>

--- a/src/main/webapp/app/components/account/ActivateAccount.tsx
+++ b/src/main/webapp/app/components/account/ActivateAccount.tsx
@@ -19,6 +19,7 @@ export default class ActivateAccount extends React.Component<{
   routing: RouterStore;
 }> {
   @observable activateKey: string;
+  @observable login: string;
 
   constructor(props: Readonly<{ routing: RouterStore }>) {
     super(props);
@@ -27,16 +28,20 @@ export default class ActivateAccount extends React.Component<{
     if (queryStrings.key) {
       this.activateKey = queryStrings.key as string;
     }
+    if (queryStrings.login) {
+      this.login = queryStrings.login as string;
+    }
   }
 
   readonly activateAccount = remoteData<boolean>({
     invoke: () => {
-      if (this.activateKey) {
+      if (this.activateKey && this.login) {
         return client.activateAccountUsingGET({
           key: this.activateKey,
+          login: this.login,
         });
       } else {
-        return Promise.reject('The key is empty');
+        return Promise.reject('The key or login is empty');
       }
     },
   });

--- a/src/main/webapp/app/shared/api/generated/API-docs.json
+++ b/src/main/webapp/app/shared/api/generated/API-docs.json
@@ -609,6 +609,13 @@
             "description": "key",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "login",
+            "in": "query",
+            "description": "login",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -1366,6 +1373,33 @@
         "deprecated": false
       }
     },
+    "/api/cronjob/move-token-stats-to-s3": {
+      "get": {
+        "tags": [
+          "cron-job-controller"
+        ],
+        "summary": "moveTokenStatsToS3",
+        "operationId": "moveTokenStatsToS3UsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
     "/api/cronjob/remove-not-activate-users": {
       "get": {
         "tags": [
@@ -1454,34 +1488,6 @@
         ],
         "summary": "analyzeUserUsage",
         "operationId": "analyzeUserUsageUsingGET",
-        "produces": [
-          "*/*"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "404": {
-            "description": "Not Found"
-          }
-        },
-        "deprecated": false
-      }
-    },
-    "/api/cronjob/move-token-stats-to-s3": {
-      "get": {
-        "tags": [
-          "cron-job-controller"
-        ],
-        "summary": "moveTokenStatsToS3",
-        "operationId": "moveTokenStatsToS3UsingGET",
-        
         "produces": [
           "*/*"
         ],

--- a/src/main/webapp/app/shared/api/generated/API.ts
+++ b/src/main/webapp/app/shared/api/generated/API.ts
@@ -1369,12 +1369,17 @@ export default class API {
     };
     activateAccountUsingGETURL(parameters: {
         'key': string,
+        'login': string,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
         let path = '/api/activate';
         if (parameters['key'] !== undefined) {
             queryParameters['key'] = parameters['key'];
+        }
+
+        if (parameters['login'] !== undefined) {
+            queryParameters['login'] = parameters['login'];
         }
 
         if (parameters.$queryParameters) {
@@ -1392,9 +1397,11 @@ export default class API {
      * @method
      * @name API#activateAccountUsingGET
      * @param {string} key - key
+     * @param {string} login - login
      */
     activateAccountUsingGETWithHttpInfo(parameters: {
         'key': string,
+        'login': string,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < request.Response > {
@@ -1418,6 +1425,15 @@ export default class API {
                 return;
             }
 
+            if (parameters['login'] !== undefined) {
+                queryParameters['login'] = parameters['login'];
+            }
+
+            if (parameters['login'] === undefined) {
+                reject(new Error('Missing required  parameter: login'));
+                return;
+            }
+
             if (parameters.$queryParameters) {
                 Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
                     var parameter = parameters.$queryParameters[parameterName];
@@ -1435,9 +1451,11 @@ export default class API {
      * @method
      * @name API#activateAccountUsingGET
      * @param {string} key - key
+     * @param {string} login - login
      */
     activateAccountUsingGET(parameters: {
         'key': string,
+        'login': string,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < boolean > {
@@ -2798,6 +2816,67 @@ export default class API {
             return response.body;
         });
     };
+    moveTokenStatsToS3UsingGETURL(parameters: {
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/api/cronjob/move-token-stats-to-s3';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * moveTokenStatsToS3
+     * @method
+     * @name API#moveTokenStatsToS3UsingGET
+     */
+    moveTokenStatsToS3UsingGETWithHttpInfo(parameters: {
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/api/cronjob/move-token-stats-to-s3';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = '*/*';
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * moveTokenStatsToS3
+     * @method
+     * @name API#moveTokenStatsToS3UsingGET
+     */
+    moveTokenStatsToS3UsingGET(parameters: {
+        $queryParameters ? : any,
+            $domain ? : string
+    }): Promise < any > {
+        return this.moveTokenStatsToS3UsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
     removeNotActivatedUsersUsingGETURL(parameters: {
         $queryParameters ? : any
     }): string {
@@ -2920,67 +2999,6 @@ export default class API {
             return response.body;
         });
     };
-    removeOldTokenStatsUsingGETURL(parameters: {
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/cronjob/remove-old-token-stats';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * removeOldTokenStats
-     * @method
-     * @name API#removeOldTokenStatsUsingGET
-     */
-    removeOldTokenStatsUsingGETWithHttpInfo(parameters: {
-        $queryParameters ? : any,
-            $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/cronjob/remove-old-token-stats';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = '*/*';
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * removeOldTokenStats
-     * @method
-     * @name API#removeOldTokenStatsUsingGET
-     */
-    removeOldTokenStatsUsingGET(parameters: {
-        $queryParameters ? : any,
-            $domain ? : string
-    }): Promise < any > {
-        return this.removeOldTokenStatsUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
-            return response.body;
-        });
-    };
     tokensRenewCheckUsingGETURL(parameters: {
         $queryParameters ? : any
     }): string {
@@ -3039,67 +3057,6 @@ export default class API {
             $domain ? : string
     }): Promise < any > {
         return this.tokensRenewCheckUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
-            return response.body;
-        });
-    };
-    updateTokenStatsUsingGETURL(parameters: {
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/cronjob/update-token-stats';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * updateTokenStats
-     * @method
-     * @name API#updateTokenStatsUsingGET
-     */
-    updateTokenStatsUsingGETWithHttpInfo(parameters: {
-        $queryParameters ? : any,
-            $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/cronjob/update-token-stats';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = '*/*';
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * updateTokenStats
-     * @method
-     * @name API#updateTokenStatsUsingGET
-     */
-    updateTokenStatsUsingGET(parameters: {
-        $queryParameters ? : any,
-            $domain ? : string
-    }): Promise < any > {
-        return this.updateTokenStatsUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });
     };

--- a/src/test/java/org/mskcc/cbio/oncokb/web/rest/AccountResourceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/web/rest/AccountResourceIT.java
@@ -384,8 +384,9 @@ public class AccountResourceIT {
     @Transactional
     public void testActivateAccount() throws Exception {
         final String activationKey = "some activation key";
+        final String userLogin = "activate-account";
         User user = new User();
-        user.setLogin("activate-account");
+        user.setLogin(userLogin);
         user.setEmail("activate-account@example.com");
         user.setPassword(RandomStringUtils.random(60));
         user.setActivated(false);
@@ -393,7 +394,7 @@ public class AccountResourceIT {
 
         userRepository.saveAndFlush(user);
 
-        restAccountMockMvc.perform(get("/api/activate?key={activationKey}", activationKey))
+        restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))
             .andExpect(status().isOk());
 
         user = userRepository.findOneByLogin(user.getLogin()).orElse(null);
@@ -405,7 +406,36 @@ public class AccountResourceIT {
     @Test
     @Transactional
     public void testActivateAccountWithWrongKey() throws Exception {
-        restAccountMockMvc.perform(get("/api/activate?key=wrongActivationKey"))
+        final String activationKey = "some activation key";
+        final String userLogin = "activate-account";
+        User user = new User();
+        user.setLogin(userLogin);
+        user.setEmail("activate-account@example.com");
+        user.setPassword(RandomStringUtils.random(60));
+        user.setActivated(false);
+        user.setActivationKey(activationKey);
+
+        userRepository.saveAndFlush(user);
+
+        restAccountMockMvc.perform(get("/api/activate?key=wrongActivationKey&login={userLogin}", userLogin))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @Transactional
+    public void testActivateAccountWithNonExistingLogin() throws Exception {
+        final String activationKey = "some activation key";
+        final String userLogin = "activate-account";
+        User user = new User();
+        user.setLogin(userLogin);
+        user.setEmail("activate-account@example.com");
+        user.setPassword(RandomStringUtils.random(60));
+        user.setActivated(false);
+        user.setActivationKey(activationKey);
+
+        userRepository.saveAndFlush(user);
+
+        restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login=non-existing-account", activationKey))
             .andExpect(status().isInternalServerError());
     }
 


### PR DESCRIPTION
Related to https://github.com/oncokb/oncokb/issues/2995

- The activation URL should be `/account/verify?key=<key>&login=<login>`
- Users without an `activationKey` will not receive an error, but show the appropriate message based on their account status.
- If the login cannot be found or the activationKey does not match, then we throw the error