### PR TITLE
Allow admin to manually verify user email

### DIFF
--- a/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
+++ b/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
@@ -188,6 +188,27 @@ export default class CompanyPage extends React.Component<
   }
 
   @action.bound
+  async verifyUserEmail(user: UserDTO) {
+    try {
+      const activated = await client.activateAccountUsingGET({
+        key: user.activationKey,
+        login: user.login,
+      });
+      const updatedUser = {
+        ...user,
+        activated,
+        activationKey: '',
+        emailVerified: true,
+      };
+      const oldUserIndex = this.companyUsers.findIndex(u => u.id === user.id);
+      this.companyUsers.splice(oldUserIndex, 1, updatedUser);
+      notifySuccess('User email verified');
+    } catch (error) {
+      return notifyError(error);
+    }
+  }
+
+  @action.bound
   showConfirmModal(event: any, value: any) {
     this.formValues = value;
     // Show warnings when license status is being changed and there are company users
@@ -462,6 +483,7 @@ export default class CompanyPage extends React.Component<
                               usersTokens={this.companyUserTokens}
                               onRemoveUser={this.removeUserFromCompany}
                               onUpdateUser={this.updateCompanyUser}
+                              onVerifyUserEmail={this.verifyUserEmail}
                               licenseStatus={
                                 this.company.licenseStatus as LicenseStatus
                               }

--- a/src/main/webapp/app/pages/userManagement/UserDetailsPage.tsx
+++ b/src/main/webapp/app/pages/userManagement/UserDetailsPage.tsx
@@ -136,6 +136,27 @@ export default class UserDetailsPage extends React.Component<{
     this.updateUser(userToUpdate, sendEmail);
   }
 
+  @action.bound
+  async verifyUserEmail(user: UserDTO) {
+    try {
+      const activated = await client.activateAccountUsingGET({
+        key: user.activationKey,
+        login: user.login,
+      });
+      const updatedUser = {
+        ...user,
+        activated,
+        activationKey: '',
+        emailVerified: true,
+      };
+      const oldUserIndex = this.users.findIndex(u => u.id === user.id);
+      this.users.splice(oldUserIndex, 1, updatedUser);
+      notifySuccess('User email verified');
+    } catch (error) {
+      return notifyError(error);
+    }
+  }
+
   @action
   updateUser(updatedUser: UserDTO, sendEmail = false) {
     client
@@ -285,7 +306,14 @@ export default class UserDetailsPage extends React.Component<{
             </Button>
           );
         } else {
-          return <div>Email hasn&apos;t been verified yet</div>;
+          return (
+            <>
+              <div>Email hasn&apos;t been verified yet</div>
+              <Button onClick={() => this.verifyUserEmail(props.original)}>
+                Verify
+              </Button>
+            </>
+          );
         }
       },
     },

--- a/src/main/webapp/app/shared/table/UserTable.tsx
+++ b/src/main/webapp/app/shared/table/UserTable.tsx
@@ -22,6 +22,7 @@ type IUserTableProps = {
   usersTokens: Token[];
   onRemoveUser: (userToRemove: UserDTO) => void;
   onUpdateUser: (updatedUser: UserDTO) => void;
+  onVerifyUserEmail: (user: UserDTO) => void;
   loading?: boolean;
   licenseStatus?: LicenseStatus;
 };
@@ -207,7 +208,16 @@ export class UserTable extends React.Component<IUserTableProps> {
             </>
           );
         } else {
-          return <div>Email hasn&apos;t been verified yet</div>;
+          return (
+            <>
+              <div>Email hasn&apos;t been verified yet</div>
+              <Button
+                onClick={() => this.props.onVerifyUserEmail(props.original)}
+              >
+                Verify
+              </Button>
+            </>
+          );
         }
       },
     },


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3033

- Admins can verify user email manually through the user page, user table, and company user table.
  - Added a button to table's `Status` column to verify email.
  - 
![image](https://user-images.githubusercontent.com/59149377/158686113-f0c91460-5341-49aa-98d0-2c97ca8f277d.png)

- In the User Page, added radio buttons. Once the email is set to 'Verified', then cannot be set back to unverified.

![image](https://user-images.githubusercontent.com/59149377/158686170-eea97b09-388e-4454-b8b6-0c91d4fcbf17.png)

