### PR TITLE
Allow users to generate a new token.

### DIFF
--- a/src/main/webapp/app/components/accountMessage/AccountMessage.tsx
+++ b/src/main/webapp/app/components/accountMessage/AccountMessage.tsx
@@ -7,6 +7,7 @@ import AuthenticationStore, {
   ACCOUNT_STATUS,
 } from 'app/store/AuthenticationStore';
 import { ContactLink } from 'app/shared/links/ContactLink';
+import { computed } from 'mobx';
 
 @observer
 export default class AccountMessage extends React.Component<
@@ -16,9 +17,17 @@ export default class AccountMessage extends React.Component<
   },
   {}
 > {
+  @computed
+  get showAccountMessage() {
+    return (
+      this.props.authStore.accountStatus ===
+        ACCOUNT_STATUS.TRIAL_ABOUT_2_EXPIRED &&
+      this.props.authStore.isAuthenticated
+    );
+  }
+
   render() {
-    return this.props.authStore.accountStatus ===
-      ACCOUNT_STATUS.TRIAL_ABOUT_2_EXPIRED ? (
+    return this.showAccountMessage ? (
       <div className={styles.message}>
         <Container
           fluid={!this.props.windowStore.isXLscreen}

--- a/src/main/webapp/app/components/tokenInputGroups/TokenInputGroups.tsx
+++ b/src/main/webapp/app/components/tokenInputGroups/TokenInputGroups.tsx
@@ -79,8 +79,8 @@ export default class TokenInputGroups extends React.Component<
                 <DefaultTooltip
                   placement={'top'}
                   overlay={
-                    this.props.tokens.length < 2
-                      ? 'You need to have one valid token'
+                    this.isTokenDeletionDisabled(index)
+                      ? 'Cannot delete token that lasts the longest or is newly generated. Try deleting an old token first.'
                       : 'Delete the token'
                   }
                 >

--- a/src/main/webapp/app/components/tokenInputGroups/TokenInputGroups.tsx
+++ b/src/main/webapp/app/components/tokenInputGroups/TokenInputGroups.tsx
@@ -34,8 +34,9 @@ export default class TokenInputGroups extends React.Component<
     });
   }
 
-  isTokenDeletionDisabled(index: number) {
-    return index === this.props.tokens.length - 1;
+  @computed
+  get deleteTokenAllowed() {
+    return this.props.tokens.length >= 2;
   }
 
   getDuration(expireInDays: number, expireInHours: number) {
@@ -79,18 +80,18 @@ export default class TokenInputGroups extends React.Component<
                 <DefaultTooltip
                   placement={'top'}
                   overlay={
-                    this.isTokenDeletionDisabled(index)
-                      ? 'Cannot delete token that lasts the longest or is newly generated. Try deleting an old token first.'
-                      : 'Delete the token'
+                    this.deleteTokenAllowed
+                      ? 'Delete the token'
+                      : 'You need to have one valid token'
                   }
                 >
                   <InputGroup.Append>
                     <Button
                       variant={'primary'}
-                      disabled={this.isTokenDeletionDisabled(index)}
                       onClick={() => this.props.onDeleteToken(token)}
+                      disabled={!this.deleteTokenAllowed}
                       style={
-                        this.isTokenDeletionDisabled(index)
+                        !this.deleteTokenAllowed
                           ? { pointerEvents: 'none' }
                           : {}
                       }

--- a/src/main/webapp/app/pages/AccountPage.tsx
+++ b/src/main/webapp/app/pages/AccountPage.tsx
@@ -65,7 +65,7 @@ export class AccountPage extends React.Component<IRegisterProps> {
     return this.props.authenticationStore.account;
   }
 
-  @action
+  @action.bound
   deleteToken(token: Token) {
     this.props.authenticationStore
       .deleteToken(token)
@@ -96,7 +96,7 @@ export class AccountPage extends React.Component<IRegisterProps> {
       );
   }
 
-  @autobind
+  @action.bound
   addNewToken() {
     this.props.authenticationStore
       .generateIdToken()
@@ -110,7 +110,7 @@ export class AccountPage extends React.Component<IRegisterProps> {
 
   @computed
   get generateTokenEnabled() {
-    return this.enableRegenerateToken && this.tokens.length < 1;
+    return this.enableRegenerateToken && this.tokens.length < 2;
   }
 
   @computed
@@ -227,7 +227,7 @@ export class AccountPage extends React.Component<IRegisterProps> {
                       placement={'top'}
                       overlay={
                         this.enableRegenerateToken
-                          ? 'Get a new token'
+                          ? 'Get a new token. Your old token will expire in 7 days.'
                           : 'You cannot add a token at the moment, please try again later.'
                       }
                     >

--- a/src/main/webapp/app/pages/AccountPage.tsx
+++ b/src/main/webapp/app/pages/AccountPage.tsx
@@ -53,7 +53,6 @@ export const InfoRow: React.FunctionComponent<{
 @inject('authenticationStore')
 @observer
 export class AccountPage extends React.Component<IRegisterProps> {
-  @observable enableRegenerateToken = true;
   @observable copiedIdToken = false;
 
   constructor(props: Readonly<IRegisterProps>) {
@@ -103,14 +102,14 @@ export class AccountPage extends React.Component<IRegisterProps> {
       .then(() => {
         notifySuccess('Token is added');
       })
-      .catch(() => {
-        this.enableRegenerateToken = false;
+      .catch(error => {
+        notifyError(error);
       });
   }
 
   @computed
   get generateTokenEnabled() {
-    return this.enableRegenerateToken && this.tokens.length < 2;
+    return this.tokens.length < 2;
   }
 
   @computed
@@ -225,24 +224,12 @@ export class AccountPage extends React.Component<IRegisterProps> {
                   {this.generateTokenEnabled ? (
                     <DefaultTooltip
                       placement={'top'}
-                      overlay={
-                        this.enableRegenerateToken
-                          ? 'Get a new token. Your old token will expire in 7 days or less.'
-                          : 'You cannot add a token at the moment, please try again later.'
-                      }
+                      overlay={'Get a new token.'}
                     >
-                      {this.enableRegenerateToken ? (
-                        <i
-                          className={classnames('ml-2 fa fa-plus')}
-                          onClick={this.addNewToken}
-                        ></i>
-                      ) : (
-                        <i
-                          className={classnames(
-                            'ml-2 fa fa-exclamation-triangle text-warning'
-                          )}
-                        ></i>
-                      )}
+                      <i
+                        className={classnames('ml-2 fa fa-plus')}
+                        onClick={this.addNewToken}
+                      />
                     </DefaultTooltip>
                   ) : null}
                 </div>

--- a/src/main/webapp/app/pages/AccountPage.tsx
+++ b/src/main/webapp/app/pages/AccountPage.tsx
@@ -227,7 +227,7 @@ export class AccountPage extends React.Component<IRegisterProps> {
                       placement={'top'}
                       overlay={
                         this.enableRegenerateToken
-                          ? 'Get a new token. Your old token will expire in 7 days.'
+                          ? 'Get a new token. Your old token will expire in 7 days or less.'
                           : 'You cannot add a token at the moment, please try again later.'
                       }
                     >

--- a/src/main/webapp/app/pages/userPage/UserPage.tsx
+++ b/src/main/webapp/app/pages/userPage/UserPage.tsx
@@ -58,6 +58,7 @@ import { RouterStore } from 'mobx-react-router';
 import { SHORT_TEXT_VAL } from 'app/shared/utils/FormValidationUtils';
 import classnames from 'classnames';
 import AuthenticationStore from 'app/store/AuthenticationStore';
+import ButtonWithTooltip from 'app/shared/button/ButtonWithTooltip';
 
 export enum AccountStatus {
   ACTIVATED = 'Activated',
@@ -523,30 +524,22 @@ export default class UserPage extends React.Component<IUserPage> {
                             extendExpirationDate={this.extendExpirationDate}
                           />
                           <div className="mt-2 d-flex flex-row-reverse">
-                            <DefaultTooltip
-                              placement={'top'}
-                              overlay={
-                                this.userTokens.length > 1
-                                  ? 'Cannot generate token when there is more than one token associated with user.'
-                                  : "Create new token. User's old token will expire in 7 days if expiration is longer than 7 days."
-                              }
-                            >
-                              <div>
-                                <Button
-                                  variant={'primary'}
-                                  size="sm"
-                                  onClick={this.addNewToken}
-                                  disabled={this.userTokens.length > 1}
-                                  style={
-                                    this.userTokens.length > 1
-                                      ? { pointerEvents: 'none' }
-                                      : {}
-                                  }
-                                >
-                                  New Token
-                                </Button>
-                              </div>
-                            </DefaultTooltip>
+                            <ButtonWithTooltip
+                              tooltipProps={{
+                                placement: 'top',
+                                overlay:
+                                  this.userTokens.length > 1
+                                    ? 'Cannot generate token when there is more than one token associated with user.'
+                                    : "Create new token. User's old token will expire in 7 days if expiration is longer than 7 days.",
+                              }}
+                              buttonProps={{
+                                variant: 'primary',
+                                size: 'sm',
+                                onClick: () => this.addNewToken(),
+                                disabled: this.userTokens.length > 1,
+                              }}
+                              buttonContent={'New Token'}
+                            />
                           </div>
                         </Col>
                       </Row>

--- a/src/main/webapp/app/pages/userPage/UserPage.tsx
+++ b/src/main/webapp/app/pages/userPage/UserPage.tsx
@@ -154,7 +154,7 @@ export default class UserPage extends React.Component<IUserPage> {
     this.props.authenticationStore
       .generateIdToken()
       .then((token: Token) => {
-        this.userTokens.push(token);
+        this.getUserTokens();
         notifySuccess('New token created.');
       })
       .catch(error => {
@@ -167,9 +167,7 @@ export default class UserPage extends React.Component<IUserPage> {
     client
       .deleteTokenUsingDELETE({ token })
       .then(() => {
-        this.userTokens = this.userTokens.filter(
-          userToken => userToken.id !== token.id
-        );
+        this.getUserTokens();
         notifySuccess('Token is deleted');
       })
       .catch((error: Error) => {

--- a/src/main/webapp/app/shared/button/ButtonWithTooltip.tsx
+++ b/src/main/webapp/app/shared/button/ButtonWithTooltip.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { DefaultTooltip } from 'cbioportal-frontend-commons';
+import { DefaultTooltipProps } from 'cbioportal-frontend-commons/dist/components/defaultTooltip/DefaultTooltip';
+import { Button, ButtonProps } from 'react-bootstrap';
+
+/**
+ * Disabled elements need to be wrapped in a div or span, otherwise the tooltip
+ * will not show because mouse events are not triggered on disabled elements.
+ * See https://getbootstrap.com/docs/3.4/javascript/#tooltips
+ * Also https://github.com/react-component/tooltip/issues/18 highlights some issues
+ * related to tooltip.
+ */
+
+const ButtonWithTooltip: React.FunctionComponent<{
+  tooltipProps: DefaultTooltipProps;
+  buttonProps: ButtonProps;
+  buttonContent: string | JSX.Element;
+}> = props => {
+  const { tooltipProps, buttonProps, buttonContent } = props;
+  const button = (
+    <Button
+      style={buttonProps.disabled ? { pointerEvents: 'none' } : {}}
+      {...buttonProps}
+    >
+      {buttonContent}
+    </Button>
+  );
+  return (
+    <DefaultTooltip {...tooltipProps}>
+      {buttonProps.disabled ? (
+        <span
+          style={{
+            cursor: `${buttonProps.disabled ? 'not-allowed' : 'pointer'}`,
+          }}
+        >
+          {button}
+        </span>
+      ) : (
+        button
+      )}
+    </DefaultTooltip>
+  );
+};
+
+export default ButtonWithTooltip;

--- a/src/main/webapp/app/shared/button/CopyButton.tsx
+++ b/src/main/webapp/app/shared/button/CopyButton.tsx
@@ -28,11 +28,11 @@ export const CopyButton: React.FunctionComponent<
         format: 'text/plain',
       }}
     >
-      <Button variant={'primary'} onClick={onCopy} {...rest}>
-        <DefaultTooltip placement={'top'} overlay={copied ? 'Copied' : 'Copy'}>
+      <DefaultTooltip placement={'top'} overlay={copied ? 'Copied' : 'Copy'}>
+        <Button variant={'primary'} onClick={onCopy} {...rest}>
           <i className={classnames('fa fa-copy')}></i>
-        </DefaultTooltip>
-      </Button>
+        </Button>
+      </DefaultTooltip>
     </CopyToClipboard>
   );
 };

--- a/src/main/webapp/app/store/AuthenticationStore.ts
+++ b/src/main/webapp/app/store/AuthenticationStore.ts
@@ -115,7 +115,7 @@ class AuthenticationStore {
         .then((token: Token) => {
           this.getAccountTokens()
             .then(() => {
-              resolve(this.idToken);
+              resolve(token);
             })
             .catch(error => {
               reject(error);


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3035

### Changes
- User tokens are sorted by their lengths, so the last token (longest) cannot be deleted.
- Users can generate new token if they have only 1 token. 
- When user generates a new token, the old token will expire in `min(7 days, current expiration)`.

### New Changes
- User can delete any token now. The token's expiration will be applied to another token.

Other:
- Fixed tooltip not showing on disabled buttons.
- `AccountMessage` shows the trial about to expire banner at top of page even when the user logged out, so that is fixed.
