### PR TITLE
Update user info restriction

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/UserDTO.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/UserDTO.java
@@ -27,10 +27,12 @@ public class UserDTO {
     @Size(min = 1, max = 50)
     private String login;
 
-    @Size(max = 50)
+    @NotBlank
+    @Size(min = 2, max = 50)
     private String firstName;
 
-    @Size(max = 50)
+    @NotBlank
+    @Size(min = 2, max = 50)
     private String lastName;
 
     private LicenseType licenseType;
@@ -39,10 +41,13 @@ public class UserDTO {
 
     private CompanyDTO company;
 
+    @Size(min = 2)
     private String companyName;
 
+    @Size(min = 2)
     private String city;
 
+    @Size(min = 2)
     private String country;
 
     private AdditionalInfoDTO additionalInfo;

--- a/src/main/webapp/app/shared/utils/FormValidationUtils.tsx
+++ b/src/main/webapp/app/shared/utils/FormValidationUtils.tsx
@@ -73,9 +73,9 @@ export const textValidation = (minLength?: number, maxLength?: number) => {
   return validation;
 };
 
-export const TEXT_VAL = textValidation(1, 255);
+export const TEXT_VAL = textValidation(2, 255);
 
-export const SHORT_TEXT_VAL = textValidation(1, 50);
+export const SHORT_TEXT_VAL = textValidation(2, 50);
 
 export const EMAIL_VAL = {
   required: {


### PR DESCRIPTION
- companyName/city/country are required to have at least two characters
    - we cannot force the not empty requirement yet because the company model does not have city/country and creating user through company page does not enforce the info
- first/last name are required to have at least two characters and not empty

This fixes https://github.com/oncokb/oncokb/issues/3112