### PR TITLE
Remove inactivated trial account's information when user license changes to regular

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/Constants.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/Constants.java
@@ -34,6 +34,8 @@ public final class Constants {
     public static final String RESOURCES_USAGE_DETAIL_FILE = "public-website/usage-analysis/resourceDetail.json";
     public static final String TOKEN_STATS_STORAGE_FILE_PREFIX = "public-website/token-usage/token-stats_";
 
+    public static final String ONCOKB_TM = "OncoKB™";
+
     private Constants() {
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/security/jwt/TokenProvider.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/security/jwt/TokenProvider.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import io.github.jhipster.config.JHipsterProperties;

--- a/src/main/java/org/mskcc/cbio/oncokb/security/uuid/TokenProvider.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/security/uuid/TokenProvider.java
@@ -10,14 +10,12 @@ import org.mskcc.cbio.oncokb.service.TokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import java.security.Key;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
@@ -27,6 +27,7 @@ import org.mskcc.cbio.oncokb.domain.enumeration.*;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
 import org.mskcc.cbio.oncokb.service.mapper.UserMapper;
+import org.mskcc.cbio.oncokb.util.ObjectUtil;
 import org.mskcc.cbio.oncokb.web.rest.slack.ActionId;
 import org.mskcc.cbio.oncokb.web.rest.slack.BlockId;
 import org.slf4j.Logger;
@@ -398,7 +399,7 @@ public class SlackService {
 
     public boolean withTrialAccountNote(UserDTO userDTO, ActionId actionId) {
         if (
-            userDTO.getAdditionalInfo() == null
+            ObjectUtil.isUserAdditionalInfoEmpty(userDTO.getAdditionalInfo())
                 || userDTO.getAdditionalInfo().getTrialAccount() == null
                 || userDTO.getAdditionalInfo().getTrialAccount().getActivation() == null
         ) {

--- a/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
@@ -399,7 +399,7 @@ public class SlackService {
 
     public boolean withTrialAccountNote(UserDTO userDTO, ActionId actionId) {
         if (
-            ObjectUtil.isUserAdditionalInfoEmpty(userDTO.getAdditionalInfo())
+            ObjectUtil.isObjectEmpty(userDTO.getAdditionalInfo())
                 || userDTO.getAdditionalInfo().getTrialAccount() == null
                 || userDTO.getAdditionalInfo().getTrialAccount().getActivation() == null
         ) {

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -302,7 +302,7 @@ public class UserService {
 
     public boolean trialAccountInitiated(UserDTO userDTO) {
         if (
-            ObjectUtil.isUserAdditionalInfoEmpty(userDTO.getAdditionalInfo())
+            ObjectUtil.isObjectEmpty(userDTO.getAdditionalInfo())
                 || userDTO.getAdditionalInfo().getTrialAccount() == null
                 || userDTO.getAdditionalInfo().getTrialAccount().getActivation() == null
         ) {

--- a/src/main/java/org/mskcc/cbio/oncokb/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/impl/CompanyServiceImpl.java
@@ -6,7 +6,6 @@ import org.mskcc.cbio.oncokb.config.cache.CacheNameResolver;
 import org.mskcc.cbio.oncokb.domain.Company;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseStatus;
 import org.mskcc.cbio.oncokb.repository.CompanyRepository;
-import org.mskcc.cbio.oncokb.repository.UserRepository;
 import org.mskcc.cbio.oncokb.service.dto.CompanyDTO;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.mapper.CompanyDomainMapper;

--- a/src/main/java/org/mskcc/cbio/oncokb/util/ObjectUtil.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/util/ObjectUtil.java
@@ -1,0 +1,19 @@
+package org.mskcc.cbio.oncokb.util;
+
+import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
+
+public class ObjectUtil {
+    
+    /**
+     * Checks if a AdditionalInfoDTO is empty or null. AdditionalInfoDTO is empty if its fields are all empty as well.
+     * 
+     * @param additionalInfoDTO the user's additionalInfoDTO
+     * @return true if null or empty, otherwise false
+     */
+    public static boolean isUserAdditionalInfoEmpty(AdditionalInfoDTO additionalInfoDTO) {
+        if (additionalInfoDTO == null) {
+            return true;
+        }
+        return additionalInfoDTO.getTrialAccount() == null && additionalInfoDTO.getUserCompany() == null;
+    }
+}

--- a/src/main/java/org/mskcc/cbio/oncokb/util/ObjectUtil.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/util/ObjectUtil.java
@@ -1,19 +1,21 @@
 package org.mskcc.cbio.oncokb.util;
 
-import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
+import com.google.gson.Gson;
 
 public class ObjectUtil {
-    
+
     /**
-     * Checks if a AdditionalInfoDTO is empty or null. AdditionalInfoDTO is empty if its fields are all empty as well.
-     * 
-     * @param additionalInfoDTO the user's additionalInfoDTO
-     * @return true if null or empty, otherwise false
+     * Check if the object is empty or null. Object is empty if all fields are null.
+     * @param <T> Type of the object
+     * @param object object
+     * @return true if object is empty
      */
-    public static boolean isUserAdditionalInfoEmpty(AdditionalInfoDTO additionalInfoDTO) {
-        if (additionalInfoDTO == null) {
+    public static <T> boolean isObjectEmpty(T object) {
+        if (object == null) {
             return true;
         }
-        return additionalInfoDTO.getTrialAccount() == null && additionalInfoDTO.getUserCompany() == null;
+        // Gson doesn't serialize null fields by default. If all fields are null, then a string representation of empty object is returned.
+        String json = new Gson().toJson(object);
+        return json.equals("{}");
     }
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -28,7 +28,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
-import javax.mail.MessagingException;
 import javax.naming.AuthenticationException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -171,7 +170,7 @@ public class AccountResource {
             if (companyCandidate.getCompanyCandidate().isPresent()) {
                 limitedCompany = companyCandidate.getCompanyCandidate().get();
             }
-            slackService.sendUserRegistrationToChannel(userDTO, userService.trialAccountActivated(userDTO), limitedCompany);
+            slackService.sendUserRegistrationToChannel(userDTO, userService.isUserOnTrial(userDTO), limitedCompany);
         } else {
             Company company = companyCandidate.getCompanyCandidate().get();
             userService.updateUserWithCompanyLicense(userDTO, company, false, false);

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/SlackController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/SlackController.java
@@ -113,12 +113,12 @@ public class SlackController {
                         this.userService.updateUser(userDTO);
                         break;
                     case CONVERT_TO_REGULAR_ACCOUNT:
-                        userService.convertTrialUserToRegular(userDTO);
+                        userService.convertUserToRegular(userDTO);
                         break;
                     default:
                         break;
                 }
-                this.slackService.sendLatestBlocks(blockActionPayload.getResponseUrl(), userDTO, userService.trialAccountActivated(userDTO), actionId, blockActionPayload.getTriggerId());
+                this.slackService.sendLatestBlocks(blockActionPayload.getResponseUrl(), userDTO, userService.isUserOnTrial(userDTO), actionId, blockActionPayload.getTriggerId());
             }
         } else if (pl.getType().equals(ViewSubmissionPayload.TYPE)) {
             ViewSubmissionPayload viewSubmissionPayload = snakeCase.fromJson(actionJSON, ViewSubmissionPayload.class);
@@ -166,7 +166,7 @@ public class SlackController {
                 this.slackService.sendLatestBlocks(
                     viewSubmissionPayload.getResponseUrls().get(0).getResponseUrl(),
                     userDTO,
-                    userService.trialAccountActivated(userDTO),
+                    userService.isUserOnTrial(userDTO),
                     ActionId.getById(viewSubmissionPayload.getView().getCallbackId()),
                     null);
             }

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/errors/LicenseAgreementNotAcceptedException.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/errors/LicenseAgreementNotAcceptedException.java
@@ -1,6 +1,7 @@
 package org.mskcc.cbio.oncokb.web.rest.errors;
 
 import java.util.Map;
+import org.mskcc.cbio.oncokb.config.Constants;
 
 import org.zalando.problem.AbstractThrowableProblem;
 import org.zalando.problem.Status;
@@ -12,7 +13,7 @@ public class LicenseAgreementNotAcceptedException extends AbstractThrowableProbl
     public LicenseAgreementNotAcceptedException(Map<String, Object> parameters) {
         super(
             ErrorConstants.LICENSE_AGREEMENT_NOT_ACCEPTED, 
-            "You have not accepted the OncoKB trial license agreement", 
+            String.format("You have not accepted the %s trial license agreement", Constants.ONCOKB_TM), 
             Status.UNAUTHORIZED,
             null,
             null,

--- a/src/test/java/org/mskcc/cbio/oncokb/service/CompanyServiceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/CompanyServiceIT.java
@@ -226,6 +226,8 @@ public class CompanyServiceIT {
         UserDTO userDTOPost = userMapper.userToUserDTO(optionalUserPost.get());
         assertThat(userDTOPost.getAdditionalInfo()).isNotNull();
         assertThat(userDTOPost.getAdditionalInfo().getTrialAccount()).isNotNull();
+        assertThat(userDTOPost.getAdditionalInfo().getTrialAccount().getActivation().getActivationDate())
+            .isCloseTo(Instant.now(), within(timeDiffToleranceInMilliseconds, ChronoUnit.MILLIS));
         List<Token> tokens = tokenService.findByUser(userMapper.userDTOToUser(userDTOPost));
         assertThat(tokens).extracting(Token::isRenewable).allMatch(renewable -> renewable.equals(true));
     }

--- a/src/test/java/org/mskcc/cbio/oncokb/service/UserServiceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/UserServiceIT.java
@@ -1,13 +1,13 @@
 package org.mskcc.cbio.oncokb.service;
 
-import org.mskcc.cbio.oncokb.RedisTestContainerExtension;
 import org.mskcc.cbio.oncokb.OncokbPublicApp;
 import org.mskcc.cbio.oncokb.config.Constants;
 import org.mskcc.cbio.oncokb.domain.Token;
-import org.mskcc.cbio.oncokb.domain.Token_;
 import org.mskcc.cbio.oncokb.domain.User;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
+import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
+import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.TrialAccount;
 import org.mskcc.cbio.oncokb.service.mapper.UserMapper;
 
 import io.github.jhipster.security.RandomUtil;
@@ -15,7 +15,6 @@ import io.github.jhipster.security.RandomUtil;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,8 +29,10 @@ import java.time.temporal.ChronoUnit;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.when;
 
 /**
@@ -52,6 +53,10 @@ public class UserServiceIT {
     private static final String DEFAULT_IMAGEURL = "http://placehold.it/50x50";
 
     private static final String DEFAULT_LANGKEY = "dummy";
+
+    private static final Integer DEFAULT_TRIAL_PERIOD_IN_DAYS = 90;
+
+    private static final Long timeDiffToleranceInMilliseconds = 1000L;
 
     @Autowired
     private UserRepository userRepository;
@@ -175,6 +180,138 @@ public class UserServiceIT {
         assertThat(tokens.stream()
             .allMatch(token -> token.isRenewable().equals(false)))
             .isTrue();
+    }
+
+    @Test
+    public void assertThatUserHasUnactivatedTrial() {
+        User savedUser = userRepository.saveAndFlush(user);
+        UserDTO userDTO = userMapper.userToUserDTO(savedUser);
+
+        // Null check
+        assertThat(userService.userHasUnactivatedTrial(null)).isFalse();
+
+        // Prpoerty null check
+        AdditionalInfoDTO additionalInfo = null;
+        userDTO.setAdditionalInfo(additionalInfo);
+        assertThat(userService.userHasUnactivatedTrial(userDTO)).isFalse();
+
+        // Another property null check
+        additionalInfo = new AdditionalInfoDTO();
+        additionalInfo.setTrialAccount(new TrialAccount());
+        userDTO.setAdditionalInfo(additionalInfo);
+        assertThat(userService.userHasUnactivatedTrial(userDTO)).isFalse();
+
+        // Check trial account initiated, but not activated
+        Optional<User> unactivatedUser = userService.initiateTrialAccountActivation(userDTO.getLogin());
+        UserDTO unactivatedUserDTO = userMapper.userToUserDTO(unactivatedUser.get());
+        Boolean unactivatedUserResult = userService.userHasUnactivatedTrial(unactivatedUserDTO);
+        assertThat(unactivatedUserResult).isTrue();
+
+        // Check trial account activated
+        Optional<UserDTO> activatedUserDTO = userService.finishTrialAccountActivation(unactivatedUserDTO.getAdditionalInfo().getTrialAccount().getActivation().getKey());
+        Boolean activatedUserResult = userService.userHasUnactivatedTrial(activatedUserDTO.get());
+        assertThat(activatedUserResult).isFalse();
+    }
+
+    @Test
+    public void assertThatUserWithAtleastOneRenewableTokenIsRegular() {
+        User savedUser = userRepository.saveAndFlush(user);
+
+        Token renewableToken = new Token();
+        renewableToken.setToken(UUID.randomUUID());
+        renewableToken.setUser(savedUser);
+        renewableToken.setRenewable(true);
+
+        Token nonRenewableToken = new Token();
+        nonRenewableToken.setToken(UUID.randomUUID());
+        nonRenewableToken.setUser(savedUser);
+        nonRenewableToken.setRenewable(false);
+
+        // User with one renewable token should be regular user.
+        tokenService.save(renewableToken);
+        Optional<User> optionalUser = userRepository.findOneById(savedUser.getId());
+        UserDTO userDTO = userMapper.userToUserDTO(optionalUser.get());
+        assertThat(userService.isUserOnTrial(userDTO)).isFalse();
+
+        // User with atleast one renewable token should be regular user.
+        tokenService.save(nonRenewableToken);
+        Optional<User> optionalUser2 = userRepository.findOneById(savedUser.getId());
+        UserDTO userDTO2 = userMapper.userToUserDTO(optionalUser2.get());
+        assertThat(userService.isUserOnTrial(userDTO2)).isFalse();
+    }
+
+    @Test
+    public void assertThatUserWithOnlyNonRenewableTokensIsOnTrial() {
+        User savedUser = userRepository.saveAndFlush(user);
+
+        Token nonRenewableToken = new Token();
+        nonRenewableToken.setToken(UUID.randomUUID());
+        nonRenewableToken.setUser(savedUser);
+        nonRenewableToken.setRenewable(false);
+
+        Token nonRenewableToken2 = new Token();
+        nonRenewableToken2.setToken(UUID.randomUUID());
+        nonRenewableToken2.setUser(savedUser);
+        nonRenewableToken2.setRenewable(false);
+
+        // User with one non renewable token is on trial.
+        tokenService.save(nonRenewableToken);
+        Optional<User> optionalUser = userRepository.findOneById(savedUser.getId());
+        UserDTO userDTO = userMapper.userToUserDTO(optionalUser.get());
+        assertThat(userService.isUserOnTrial(userDTO)).isTrue();
+
+        // User with one or more renewable token is on trial.
+        tokenService.save(nonRenewableToken2);
+        Optional<User> optionalUser2 = userRepository.findOneById(savedUser.getId());
+        UserDTO userDTO2 = userMapper.userToUserDTO(optionalUser2.get());
+        assertThat(userService.isUserOnTrial(userDTO2)).isTrue();
+    }
+
+    @Test
+    public void assertThatApprovedTrialUserTokenLengthRenewedWhenApproved() {
+        User savedUser = userRepository.saveAndFlush(user);
+
+        Token nonRenewableToken = new Token();
+        nonRenewableToken.setToken(UUID.randomUUID());
+        nonRenewableToken.setUser(savedUser);
+        nonRenewableToken.setExpiration(Instant.now().plus(DEFAULT_TRIAL_PERIOD_IN_DAYS - 30, ChronoUnit.DAYS));
+        nonRenewableToken.setRenewable(false);
+
+        tokenService.save(nonRenewableToken);
+        Optional<User> optionalUser = userRepository.findOneById(savedUser.getId());
+        UserDTO userDTO = userMapper.userToUserDTO(optionalUser.get());
+        userService.approveUser(userDTO, true);
+
+        // If a user is approved and they have a trial token that is less than 90 days in length, then
+        // the token should be updated to expire in 90 days. 
+        List<Token> tokens = tokenService.findByUser(optionalUser.get());
+        assertThat(tokens).extracting(Token::isRenewable).allMatch(renewable -> renewable.equals(false));
+        assertThat(tokens.get(0).getExpiration())
+            .isCloseTo(Instant.now().plus(DEFAULT_TRIAL_PERIOD_IN_DAYS, ChronoUnit.DAYS), within(timeDiffToleranceInMilliseconds, ChronoUnit.MILLIS));
+    }
+
+    @Test
+    public void assertThatApprovedTrialUserTokenLengthPreservedIfLongerThanDefaultTrialPeriod() {
+        User savedUser = userRepository.saveAndFlush(user);
+        Instant longerUserTokenLength = Instant.now().plus(DEFAULT_TRIAL_PERIOD_IN_DAYS + 30, ChronoUnit.DAYS);
+
+        Token nonRenewableToken = new Token();
+        nonRenewableToken.setToken(UUID.randomUUID());
+        nonRenewableToken.setUser(savedUser);
+        nonRenewableToken.setExpiration(longerUserTokenLength);
+        nonRenewableToken.setRenewable(false);
+
+        tokenService.save(nonRenewableToken);
+        Optional<User> optionalUser = userRepository.findOneById(savedUser.getId());
+        UserDTO userDTO = userMapper.userToUserDTO(optionalUser.get());
+        userService.approveUser(userDTO, true);
+
+        // We have some users with longer trial periods, so their trial length should be preserved,
+        // when they are approved (ie. when adding them to a company)
+        List<Token> tokens = tokenService.findByUser(optionalUser.get());
+        assertThat(tokens).extracting(Token::isRenewable).allMatch(renewable -> renewable.equals(false));
+        assertThat(tokens.get(0).getExpiration())
+            .isCloseTo(longerUserTokenLength, within(timeDiffToleranceInMilliseconds, ChronoUnit.MILLIS));
     }
 
 }

--- a/src/test/java/org/mskcc/cbio/oncokb/util/ObjectUtilUnitTest.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/util/ObjectUtilUnitTest.java
@@ -1,0 +1,42 @@
+package org.mskcc.cbio.oncokb.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test class for the {@link ObjectUtil} utility class.
+ */
+public class ObjectUtilUnitTest {
+    
+    @Test
+    public void isObjectEmpty() {
+        Person person = new Person();
+        assertTrue(ObjectUtil.isObjectEmpty(null));
+        assertTrue(ObjectUtil.isObjectEmpty(person));
+
+        person.setName("Name");
+        assertFalse(ObjectUtil.isObjectEmpty(person));
+
+        assertFalse(ObjectUtil.isObjectEmpty(""));
+    }
+
+    class Person {
+        String name;
+    
+        public String getName() {
+            return this.name;
+        }
+    
+        public void setName(String name) {
+            this.name = name;
+        }
+        
+    }
+
+}


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3174

Reason: A user has not activated their trial license will still have their trial account activation `key`, so this PR (https://github.com/oncokb/oncokb-public/pull/793) prevents the user from logging in. However, if the user later gets added to a regular company, that information should be cleared or else the user not be able to login.

- Fixed trial account agreement link not showing when user who hasn't agreed to terms tries to login. This was due to the OncoKB text replaced with the trademark version in the frontend, but was not reflected in the backend error constant.
- Remove trial account information when a user's license changes to regular or is expired if the trial was never activated. 
- Added a few extra test cases
