### PR TITLE
Improve User Details Page and Company Page's User Dropdown Performances

### DIFF
--- a/screenshot-test/App.screenshot.js
+++ b/screenshot-test/App.screenshot.js
@@ -140,7 +140,7 @@ function getMockResponse(url){
         body: '[]'
       };
       break;
-    case `${SERVER_URL}api/users?size=5000`:
+    case `${SERVER_URL}api/users?size=10000`:
       res = {
         status: 200,
         contentType: 'application/json',

--- a/src/main/java/org/mskcc/cbio/oncokb/config/CacheConfiguration.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/CacheConfiguration.java
@@ -93,6 +93,7 @@ public class CacheConfiguration {
         return cm -> {
             createCache(cm, org.mskcc.cbio.oncokb.config.cache.UserCacheResolver.USERS_BY_LOGIN_CACHE, jcacheConfiguration, cacheNameResolver);
             createCache(cm, org.mskcc.cbio.oncokb.config.cache.UserCacheResolver.USERS_BY_EMAIL_CACHE, jcacheConfiguration, cacheNameResolver);
+            createCache(cm, org.mskcc.cbio.oncokb.config.cache.UserCacheResolver.ALL_USERS_CACHE, jcacheConfiguration, cacheNameResolver);
 
             createCache(cm, org.mskcc.cbio.oncokb.config.cache.TokenCacheResolver.TOKEN_BY_UUID_CACHE, jcacheConfiguration, cacheNameResolver);
             createCache(cm, org.mskcc.cbio.oncokb.config.cache.TokenCacheResolver.TOKENS_BY_USER_LOGIN_CACHE, jcacheConfiguration, cacheNameResolver);

--- a/src/main/java/org/mskcc/cbio/oncokb/config/cache/UserCacheResolver.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/cache/UserCacheResolver.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 public class UserCacheResolver implements CacheResolver {
     public static String USERS_BY_LOGIN_CACHE = "usersByLogin";
     public static String USERS_BY_EMAIL_CACHE = "usersByEmail";
+    public static String ALL_USERS_CACHE = "allUsers";
 
 
     private final ApplicationProperties applicationProperties;
@@ -32,6 +33,8 @@ public class UserCacheResolver implements CacheResolver {
             caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(USERS_BY_LOGIN_CACHE)));
         } else if (context.getMethod().getName() == "findOneWithAuthoritiesByEmailIgnoreCase") {
             caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(USERS_BY_EMAIL_CACHE)));
+        } else if (context.getMethod().getName() == "getAllManagedUsers") {
+            caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(ALL_USERS_CACHE)));
         } else {
             caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(context.getMethod().getName())));
         }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/UserDetailsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/UserDetailsRepository.java
@@ -30,4 +30,7 @@ public interface UserDetailsRepository extends JpaRepository<UserDetails, Long> 
     Optional<UserDetails> findByUserIsCurrentUser();
 
     void deleteByUser(User user);
+
+    @Query("select ud.user.email from UserDetails ud where ud.company.id is null")
+    List<String> findUserEmailsByCompanyIdIsNull();
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/UserRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/UserRepository.java
@@ -2,7 +2,6 @@ package org.mskcc.cbio.oncokb.repository;
 
 import org.mskcc.cbio.oncokb.domain.User;
 
-import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Set;
 import java.util.Optional;
 import java.time.Instant;
 
@@ -45,4 +43,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findOneWithAuthoritiesByEmailIgnoreCase(String email);
 
     Page<User> findAllByLoginNot(Pageable pageable, String login);
+
+    @Query("select user, userDetails from User as user left join UserDetails as userDetails on user.id = userDetails.user WHERE user in ?1")
+    List<Object[]> findAllUsersWithUserDetailsByUsersIn(List<User> users);
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/UserDTO.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/UserDTO.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.config.Constants;
 import org.mskcc.cbio.oncokb.domain.Authority;
-import org.mskcc.cbio.oncokb.domain.Company;
 import org.mskcc.cbio.oncokb.domain.User;
 import org.mskcc.cbio.oncokb.domain.UserDetails;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
@@ -14,11 +13,12 @@ import javax.validation.constraints.*;
 import java.time.Instant;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.io.Serializable;
 
 /**
  * A DTO representing a user, with his authorities.
  */
-public class UserDTO {
+public class UserDTO implements Serializable {
 
     private Long id;
 

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/Activation.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/Activation.java
@@ -1,11 +1,12 @@
 package org.mskcc.cbio.oncokb.service.dto.useradditionalinfo;
 
 import java.time.Instant;
+import java.io.Serializable;
 
 /**
  * Created by Hongxin Zhang on 3/31/21.
  */
-public class Activation {
+public class Activation implements Serializable{
     Instant initiationDate;
     String initiatedBy;
     Instant activationDate;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/AdditionalInfoDTO.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/AdditionalInfoDTO.java
@@ -1,11 +1,13 @@
 package org.mskcc.cbio.oncokb.service.dto.useradditionalinfo;
 
+import java.io.Serializable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
  * Created by Hongxin Zhang on 3/31/21.
  */
-public class AdditionalInfoDTO {
+public class AdditionalInfoDTO implements Serializable{
     TrialAccount trialAccount;
 
     UserCompany userCompany;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/Contact.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/Contact.java
@@ -1,9 +1,11 @@
 package org.mskcc.cbio.oncokb.service.dto.useradditionalinfo;
 
+import java.io.Serializable;
+
 /**
  * Created by Hongxin Zhang on 4/28/21.
  */
-public class Contact {
+public class Contact implements Serializable {
     String email;
     String phone;
 

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/LicenseAgreement.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/LicenseAgreement.java
@@ -1,11 +1,12 @@
 package org.mskcc.cbio.oncokb.service.dto.useradditionalinfo;
 
 import java.time.Instant;
+import java.io.Serializable;
 
 /**
  * Created by Hongxin Zhang on 3/31/21.
  */
-public class LicenseAgreement {
+public class LicenseAgreement implements Serializable {
     String name;
     String version;
     Instant acceptanceDate;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/TrialAccount.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/TrialAccount.java
@@ -1,9 +1,11 @@
 package org.mskcc.cbio.oncokb.service.dto.useradditionalinfo;
 
+import java.io.Serializable;
+
 /**
  * Created by Hongxin Zhang on 3/31/21.
  */
-public class TrialAccount {
+public class TrialAccount implements Serializable {
     Activation activation;
     LicenseAgreement licenseAgreement;
 

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/UserCompany.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/useradditionalinfo/UserCompany.java
@@ -1,9 +1,11 @@
 package org.mskcc.cbio.oncokb.service.dto.useradditionalinfo;
 
+import java.io.Serializable;
+
 /**
  * Created by Hongxin Zhang on 4/27/21.
  */
-public class UserCompany {
+public class UserCompany implements Serializable {
     String description;
     Contact businessContact;
     String size;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/mapper/UserMapper.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/mapper/UserMapper.java
@@ -35,12 +35,15 @@ public class UserMapper {
 
     public UserDTO userToUserDTO(User user) {
         Optional<UserDetails> userDetails = userDetailsRepository.findOneByUser(user);
-        if(userDetails.isPresent()) {
-            UserDTO userDTO = new UserDTO(user, userDetails.get());
-            userDTO.setCompany(companyMapper.toDto(userDetails.get().getCompany()));
-            return userDTO;
+        return userToUserDTO(user, userDetails.orElse(null));
+    }
+
+    public UserDTO userToUserDTO(User user, UserDetails userDetails) {
+        UserDTO userDTO = new UserDTO(user, userDetails);
+        if (userDetails != null) {
+            userDTO.setCompany(companyMapper.toDto(userDetails.getCompany()));
         }
-        return new UserDTO(user, null);
+        return userDTO;
     }
 
     public List<User> userDTOsToUsers(List<UserDTO> userDTOs) {

--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -344,7 +344,7 @@ export const H5_FONT_SIZE = '1.25rem';
 export const FONT_FAMILY = "'Gotham Book', sans-serif";
 
 // we do not have the table component to support api pagination, have to set the threshold to pull the list of all users
-export const THRESHOLD_NUM_OF_USER = 5000;
+export const THRESHOLD_NUM_OF_USER = 10000;
 
 // Defaults for tooltip size
 export const TOOLTIP_MAX_HEIGHT = 300;


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2342


- Cache `getAllManagedUsers` method in `UserService.java`
- Update `usersToUserDTOs` method to fetch user + user details in bulk
- Update `getNonCompanyUserEmails` method in `UserService.java` to use custom query
   - The original query takes about 7-8 seconds, but the custom query takes ~50ms.