### PR TITLE
Build multi-platforms docker image using latest jib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <frontend-maven-plugin.version>1.10.0</frontend-maven-plugin.version>
         <git-commit-id-plugin.version>4.0.0</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-        <jib-maven-plugin.version>2.4.0</jib-maven-plugin.version>
+        <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
@@ -646,7 +646,17 @@
                     <version>${jib-maven-plugin.version}</version>
                     <configuration>
                         <from>
-                            <image>adoptopenjdk:11-jre-hotspot</image>
+                            <image>eclipse-temurin:11-jre</image>
+                            <platforms>
+                                <platform>
+                                    <architecture>amd64</architecture>
+                                    <os>linux</os>
+                                </platform>
+                                <platform>
+                                    <architecture>arm64</architecture>
+                                    <os>linux</os>
+                                </platform>
+                            </platforms>
                         </from>
                         <to>
                             <image>oncokb/oncokb-public:latest</image>


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb/issues/3271

## Changes
- Update jib to v3.3.0(checked the history, didn't see breaking changes)
- Update default base image to eclipse-temurin. adoptopenjdk is deprecated(https://hub.docker.com/_/adoptopenjdk) and jib has changed to eclipse-temurin in v3.2.0
- Build both amd64 and arm64 images so we can use arm64 image in AWS Graviton server