### PR TITLE
Define defaultPageSize instead of size for most of OncoKBTable usage

### DIFF
--- a/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
+++ b/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
@@ -718,7 +718,7 @@ export default class CompanyPage extends React.Component<
                               ]}
                               showPagination={true}
                               minRows={1}
-                              pageSize={5}
+                              defaultPageSize={5}
                               filters={() => {
                                 return (
                                   <Row>

--- a/src/main/webapp/app/pages/usageAnalysisPage/UserUsageDetailsTable.tsx
+++ b/src/main/webapp/app/pages/usageAnalysisPage/UserUsageDetailsTable.tsx
@@ -33,7 +33,7 @@ type IUserUsageDetailsTable = {
   loadedData: boolean;
   defaultResourcesType: ToggleValue;
   defaultTimeType: ToggleValue;
-  pageSize?: number;
+  defaultPageSize?: number;
 };
 
 @observer
@@ -159,7 +159,7 @@ export default class UserUsageDetailsTable extends React.Component<
           ]}
           showPagination={true}
           minRows={1}
-          pageSize={this.props.pageSize}
+          defaultPageSize={this.props.defaultPageSize}
           filters={() => {
             return (
               <Row>

--- a/src/main/webapp/app/pages/userPage/UserPage.tsx
+++ b/src/main/webapp/app/pages/userPage/UserPage.tsx
@@ -121,7 +121,8 @@ export default class UserPage extends React.Component<IUserPage> {
   @observable showTrialAccountModal = false;
   @observable showTrialAccountConfirmModal = false;
   @observable showDeleteAccountConfirmModal = false;
-  @observable tablePageSize = 5;
+
+  private defaultPageSize = 5;
 
   readonly reactions: IReactionDisposer[] = [];
 
@@ -914,7 +915,7 @@ export default class UserPage extends React.Component<IUserPage> {
                             loadedData={this.usageDetail.isComplete}
                             defaultResourcesType={ToggleValue.CUMULATIVE_USAGE}
                             defaultTimeType={ToggleValue.RESULTS_BY_MONTH}
-                            pageSize={this.tablePageSize}
+                            defaultPageSize={this.defaultPageSize}
                           />
                         </Col>
                       </Row>
@@ -925,7 +926,7 @@ export default class UserPage extends React.Component<IUserPage> {
                           </div>
                           <EmailTable
                             data={this.usersUserMails.result}
-                            pageSize={this.tablePageSize}
+                            defaultPageSize={this.defaultPageSize}
                           />
                         </Col>
                       </Row>

--- a/src/main/webapp/app/shared/table/EmailTable.tsx
+++ b/src/main/webapp/app/shared/table/EmailTable.tsx
@@ -8,7 +8,7 @@ import { filterByKeyword, toAppTimestampFormat } from 'app/shared/utils/Utils';
 
 type EmailTableProps = {
   data: UserMailsDTO[];
-  pageSize?: number;
+  defaultPageSize?: number;
 };
 export const EmailTable: React.FunctionComponent<EmailTableProps> = tableProps => {
   const columns: SearchColumn<UserMailsDTO>[] = [
@@ -61,7 +61,7 @@ export const EmailTable: React.FunctionComponent<EmailTableProps> = tableProps =
       columns={columns}
       showPagination={true}
       minRows={1}
-      pageSize={tableProps.pageSize}
+      defaultPageSize={tableProps.defaultPageSize}
     />
   );
 };

--- a/src/main/webapp/app/shared/table/UserTable.tsx
+++ b/src/main/webapp/app/shared/table/UserTable.tsx
@@ -310,7 +310,7 @@ export class UserTable extends React.Component<IUserTableProps> {
           columns={this.columns}
           showPagination={true}
           minRows={1}
-          pageSize={5}
+          defaultPageSize={5}
           loading={this.props.loading}
         />
         <UserStatusModal


### PR DESCRIPTION
Once the pagesize is fixed, the page size dropdown no longer works.