### PR TITLE
Use SQL query to delete all token stats

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/TokenStatsRepository.java
@@ -21,6 +21,8 @@ import java.util.List;
 public interface TokenStatsRepository extends JpaRepository<TokenStats, Long> {
     Page<TokenStats> findAllByAccessTimeBefore(Instant before, Pageable pageable);
 
+    @Modifying
+    @Query("delete from TokenStats ts where ts.accessTime < ?1")
     void deleteAllByAccessTimeBefore(Instant before);
 
     void deleteAllByTokenIn(List<Token> tokens);


### PR DESCRIPTION
The default JPA deleteBy will load all entities in memory because it's a transection and potentially it can roll back if anything goes wrong. But token stats table could be very big, we should not load all into memory. Using Query annotation together with Modifying will send a SQL query directly. Reference: https://www.baeldung.com/spring-data-jpa-modifying-annotation

This fixes https://github.com/oncokb/oncokb/issues/3314