### PR TITLE
Add quick tool to extend trial access

### DIFF
--- a/src/main/webapp/app/components/calendarButton/CalendarButton.tsx
+++ b/src/main/webapp/app/components/calendarButton/CalendarButton.tsx
@@ -1,79 +1,16 @@
-import React, { useState } from 'react';
-import {
-  InputGroup,
-  Button,
-  Dropdown,
-  DropdownButton,
-  Row,
-  Form,
-  Col,
-  Container,
-} from 'react-bootstrap';
+import React from 'react';
+import { InputGroup, DropdownButton, Container } from 'react-bootstrap';
 import classnames from 'classnames';
-import { getMomentInstance } from 'app/shared/utils/Utils';
-import DayPickerInput from 'react-day-picker/DayPickerInput';
 import 'react-day-picker/lib/style.css';
-import moment from 'moment';
-import {
-  APP_LOCAL_DATETIME_FORMAT_Z_FORCE,
-  APP_LOCAL_DATE_FORMAT,
-} from 'app/config/constants';
-import MomentLocaleUtils from 'react-day-picker/moment';
 import { DefaultTooltip } from 'cbioportal-frontend-commons';
-import pluralize from 'pluralize';
+import {
+  DateSelector,
+  DateSelectorProps,
+} from 'app/components/dateSelector/DateSelector';
 
-type CalendarButtonProps = {
-  currentDate: string;
-  afterChangeDate: (newDate: string) => void;
-};
-
-enum ExtensionType {
-  FROM_TODAY = 'Today',
-  FROM_EXPIRATION = 'Expiration Day',
-}
+type CalendarButtonProps = DateSelectorProps & {};
 
 export const CalendarButton: React.FunctionComponent<CalendarButtonProps> = props => {
-  const [extensionType, setExtensionType] = useState(ExtensionType.FROM_TODAY);
-
-  let selectedDay: Date;
-
-  function handleDayChange(day: any) {
-    selectedDay = day;
-  }
-
-  function handleSelectedDay() {
-    props.afterChangeDate(
-      moment(selectedDay).format(APP_LOCAL_DATETIME_FORMAT_Z_FORCE)
-    );
-  }
-
-  const extendSchedule: {
-    amount: number;
-    unit: moment.unitOfTime.DurationConstructor;
-    unitText: string;
-  }[] = [
-    {
-      amount: 1,
-      unit: 'w',
-      unitText: 'week',
-    },
-    {
-      amount: 1,
-      unit: 'M',
-      unitText: 'month',
-    },
-    {
-      amount: 6,
-      unit: 'M',
-      unitText: 'month',
-    },
-    {
-      amount: 1,
-      unit: 'y',
-      unitText: 'year',
-    },
-  ];
-
   return (
     <DefaultTooltip placement={'top'} overlay={'Change token expiration date'}>
       <DropdownButton
@@ -82,80 +19,10 @@ export const CalendarButton: React.FunctionComponent<CalendarButtonProps> = prop
         id="time-entend-dropdown"
       >
         <Container>
-          <div>
-            <Row>
-              <Col>Extend after</Col>
-            </Row>
-            <Form.Group as={Row}>
-              <Col>
-                <Form.Check
-                  label={ExtensionType.FROM_TODAY}
-                  type="radio"
-                  onClick={() => setExtensionType(ExtensionType.FROM_TODAY)}
-                  name="extension-choice"
-                  id="extension-type-by-today"
-                  defaultChecked
-                />
-                <Form.Check
-                  label={ExtensionType.FROM_EXPIRATION}
-                  type="radio"
-                  onClick={() =>
-                    setExtensionType(ExtensionType.FROM_EXPIRATION)
-                  }
-                  name="extension-choice"
-                  id="extension-type-by-expiration"
-                />
-              </Col>
-            </Form.Group>
-          </div>
-          <Dropdown.Divider />
-          {extendSchedule.map((val, index) => {
-            return (
-              <Dropdown.Item
-                key={`calender-quick-selection-${index}`}
-                eventKey={`${index}`}
-                style={{ textAlign: 'center' }}
-                onClick={() => {
-                  const momentInstance =
-                    extensionType === ExtensionType.FROM_TODAY
-                      ? moment()
-                      : getMomentInstance(props.currentDate);
-                  props.afterChangeDate(
-                    momentInstance
-                      .add(val.amount, val.unit)
-                      .format(APP_LOCAL_DATETIME_FORMAT_Z_FORCE)
-                  );
-                }}
-              >
-                {pluralize(val.unitText, val.amount, true)}
-              </Dropdown.Item>
-            );
-          })}
-          <Dropdown.Divider />
-          <DayPickerInput
-            onDayChange={handleDayChange}
-            inputProps={{
-              style: {
-                textAlign: 'center',
-                border: 'none',
-              },
-            }}
-            style={{ margin: '0 auto' }}
-            formatDate={MomentLocaleUtils.formatDate}
-            parseDate={MomentLocaleUtils.parseDate}
-            placeholder={`Expires on: ${getMomentInstance(
-              props.currentDate
-            ).format(APP_LOCAL_DATE_FORMAT)}`}
+          <DateSelector
+            currentDate={props.currentDate}
+            afterChangeDate={props.afterChangeDate}
           />
-          <Row className={'mt-1'}>
-            <Button
-              size={'sm'}
-              style={{ margin: '0 auto', zIndex: 0 }}
-              onClick={handleSelectedDay}
-            >
-              Set
-            </Button>
-          </Row>
         </Container>
       </DropdownButton>
     </DefaultTooltip>

--- a/src/main/webapp/app/components/dateSelector/DateSelector.tsx
+++ b/src/main/webapp/app/components/dateSelector/DateSelector.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import { Button, Dropdown, Row, Form, Col } from 'react-bootstrap';
+import { getMomentInstance } from 'app/shared/utils/Utils';
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import 'react-day-picker/lib/style.css';
+import moment from 'moment';
+import {
+  APP_LOCAL_DATETIME_FORMAT_Z_FORCE,
+  APP_LOCAL_DATE_FORMAT,
+} from 'app/config/constants';
+import MomentLocaleUtils from 'react-day-picker/moment';
+import pluralize from 'pluralize';
+import { DividerWithInfo } from 'app/components/dividerWithInfo/DividerWithInfo';
+
+export type DateSelectorProps = {
+  currentDate?: string;
+  afterChangeDate: (newDate: string) => void;
+};
+
+enum ExtensionType {
+  FROM_TODAY = 'Today',
+  FROM_EXPIRATION = 'Expiration Day',
+}
+
+export const DateSelector: React.FunctionComponent<DateSelectorProps> = props => {
+  const [extensionType, setExtensionType] = useState(ExtensionType.FROM_TODAY);
+  const baseDate = props.currentDate || new Date(Date.now()).toISOString();
+
+  let selectedDay: Date;
+
+  function handleDayChange(day: any) {
+    selectedDay = day;
+  }
+
+  function handleSelectedDay() {
+    props.afterChangeDate(
+      moment(selectedDay).format(APP_LOCAL_DATETIME_FORMAT_Z_FORCE)
+    );
+  }
+
+  const extendSchedule: {
+    amount: number;
+    unit: moment.unitOfTime.DurationConstructor;
+    unitText: string;
+  }[] = [
+    {
+      amount: 1,
+      unit: 'w',
+      unitText: 'week',
+    },
+    {
+      amount: 1,
+      unit: 'M',
+      unitText: 'month',
+    },
+    {
+      amount: 6,
+      unit: 'M',
+      unitText: 'month',
+    },
+    {
+      amount: 1,
+      unit: 'y',
+      unitText: 'year',
+    },
+  ];
+
+  return (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+    >
+      <div>
+        <Row>
+          <Col>
+            <span>Extend after{!props.currentDate && ' TODAY'}</span>
+          </Col>
+        </Row>
+        {props.currentDate && (
+          <Form.Group as={Row}>
+            <Col>
+              <Form.Check
+                label={ExtensionType.FROM_TODAY}
+                type="radio"
+                onClick={() => setExtensionType(ExtensionType.FROM_TODAY)}
+                name="extension-choice"
+                id="extension-type-by-today"
+                defaultChecked
+              />
+              {props.currentDate && (
+                <Form.Check
+                  label={ExtensionType.FROM_EXPIRATION}
+                  type="radio"
+                  onClick={() =>
+                    setExtensionType(ExtensionType.FROM_EXPIRATION)
+                  }
+                  name="extension-choice"
+                  id="extension-type-by-expiration"
+                />
+              )}
+            </Col>
+          </Form.Group>
+        )}
+      </div>
+      {extendSchedule.map((val, index) => {
+        return (
+          <Dropdown.Item
+            key={`calender-quick-selection-${index}`}
+            eventKey={`${index}`}
+            style={{ textAlign: 'center' }}
+            onClick={() => {
+              const momentInstance =
+                extensionType === ExtensionType.FROM_TODAY
+                  ? moment()
+                  : getMomentInstance(baseDate);
+              props.afterChangeDate(
+                momentInstance
+                  .add(val.amount, val.unit)
+                  .format(APP_LOCAL_DATETIME_FORMAT_Z_FORCE)
+              );
+            }}
+          >
+            {pluralize(val.unitText, val.amount, true)}
+          </Dropdown.Item>
+        );
+      })}
+      <DividerWithInfo>
+        <b>OR</b>
+      </DividerWithInfo>
+      <div>Choose a date</div>
+      <DayPickerInput
+        onDayChange={handleDayChange}
+        inputProps={{
+          style: {
+            textAlign: 'center',
+            border: 'none',
+          },
+        }}
+        style={{ margin: '0 auto' }}
+        formatDate={MomentLocaleUtils.formatDate}
+        parseDate={MomentLocaleUtils.parseDate}
+        placeholder={
+          props.currentDate &&
+          `Expires on: ${getMomentInstance(props.currentDate).format(
+            APP_LOCAL_DATE_FORMAT
+          )}`
+        }
+      />
+      <Row className={'mt-1'}>
+        <Button
+          size={'sm'}
+          style={{ margin: '0 auto', zIndex: 0 }}
+          onClick={handleSelectedDay}
+        >
+          Set
+        </Button>
+      </Row>
+    </div>
+  );
+};

--- a/src/main/webapp/app/components/dividerWithInfo/DividerWithInfo.module.scss
+++ b/src/main/webapp/app/components/dividerWithInfo/DividerWithInfo.module.scss
@@ -1,0 +1,14 @@
+.container {
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.border {
+  border-bottom: 1px solid black;
+  width: 100%;
+}
+
+.content {
+  padding: 0 10px 0 10px;
+}

--- a/src/main/webapp/app/components/dividerWithInfo/DividerWithInfo.tsx
+++ b/src/main/webapp/app/components/dividerWithInfo/DividerWithInfo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './DividerWithInfo.module.scss';
+
+export const DividerWithInfo: React.FunctionComponent<{}> = props => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.border} />
+      <span className={styles.content}>{props.children}</span>
+      <div className={styles.border} />
+    </div>
+  );
+};

--- a/src/main/webapp/app/index.scss
+++ b/src/main/webapp/app/index.scss
@@ -231,6 +231,9 @@ input[type='radio']:checked {
 .rc-tooltip-inner {
   max-width: 300px;
 }
+.rc-tooltip {
+  opacity: 1 !important;
+}
 
 // Overwrite react-table styles
 .oncokbReactTable.ReactTable {


### PR DESCRIPTION
## changes
- Add DividerWithInfo component
- Move date selector as a separate component
- Make DateSelector prop `currentDate` optional. When `currentDate` is undefined, the quick extension is based on today
- Vertical align all components within DateSelector
- this fixes https://github.com/oncokb/oncokb/issues/3308


### Tool in company page
- all users that have trial initiated will be extended to the date admin selects
![Screen Shot 2022-12-13 at 5 41 36 PM](https://user-images.githubusercontent.com/5400599/207469289-6b2dae2c-5494-45f6-b5a6-6d851fb48b9d.png)

### Tool in user page
- allow admin to change trial expiration date
![Screen Shot 2022-12-13 at 5 41 49 PM](https://user-images.githubusercontent.com/5400599/207469283-ad57cbea-0f0c-40bf-87d2-0a75a91912d0.png)

### DateSelector changes
#### New
![Screen Shot 2022-12-13 at 5 41 49 PM](https://user-images.githubusercontent.com/5400599/207469812-7f4bebce-3312-4da0-a739-68e172b15137.png)

#### Old
![Screen Shot 2022-12-13 at 5 49 17 PM](https://user-images.githubusercontent.com/5400599/207469997-f95f7bf9-4e15-4371-a3a5-948ab6fe6395.png)
