### PR TITLE
Bring the tab description to the front

### DIFF
--- a/src/main/webapp/app/components/feedback/FeedbackIcon.tsx
+++ b/src/main/webapp/app/components/feedback/FeedbackIcon.tsx
@@ -31,7 +31,12 @@ export const FeedbackIcon = (props: {
   return (
     <>
       <DefaultTooltip overlay={tooltipOverlay}>
-        <i className="fa fa-envelope-o" aria-hidden="true" onClick={onClick} />
+        <i
+          className="fa fa-envelope-o"
+          aria-hidden="true"
+          onClick={onClick}
+          style={{ cursor: 'pointer' }}
+        />
       </DefaultTooltip>
     </>
   );

--- a/src/main/webapp/app/pages/annotationPage/AlterationTableTabs.tsx
+++ b/src/main/webapp/app/pages/annotationPage/AlterationTableTabs.tsx
@@ -196,6 +196,7 @@ export default class AlterationTableTabs extends React.Component<
       ? {
           width: '80%',
           marginBottom: '-30px',
+          zIndex: 1,
         }
       : undefined;
   }
@@ -240,7 +241,7 @@ export default class AlterationTableTabs extends React.Component<
         title: tab.title,
         getContent: () => {
           return (
-            <div>
+            <div className={'d-flex flex-column'}>
               <div style={this.tabDescriptionStyle}>
                 <div>{this.getTabDescription(tab.key)}</div>
                 <ReportIssue


### PR DESCRIPTION
The dimension of the table will overshadow the description because we shifted the table up 30px.

This fixes https://github.com/oncokb/oncokb/issues/3406