### PR TITLE
Add zIndex to cancer type select in annotation page

### DIFF
--- a/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
@@ -520,6 +520,7 @@ export default class AnnotationPage extends React.Component<
                       margin: 0,
                       padding: 0,
                     }),
+                    menu: base => ({ ...base, zIndex: 10 }),
                   }}
                   tumorType={this.props.tumorType}
                   onChange={(selectedOption: any) =>


### PR DESCRIPTION
So the menu can be shown before the tab descriptions. The description has a custom z-index:1