### PR TITLE
Add alteration links to news page

### DIFF
--- a/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
@@ -4,6 +4,7 @@ import {
   CHANGED_ANNOTATION_ADDITIONAL_DRUG_SAME_LEVEL_COLUMNS,
   CHANGED_ANNOTATION_ADDITIONAL_DRUG_DIFF_LEVEL_COLUMNS,
   GENE,
+  MUTATION,
 } from 'app/pages/newsPage/NewsPageContent';
 import { SimpleTable, SimpleTableRow } from 'app/components/SimpleTable';
 import { Row } from 'react-bootstrap';
@@ -11,7 +12,12 @@ import React from 'react';
 import _ from 'lodash';
 
 import mainStyle from './main.module.scss';
-import { convertGeneInputToLinks, getColumnIndexByName } from './Util';
+import {
+  convertGeneInputToLinks,
+  convertGeneAndAlterationInputToLink,
+  getColumnIndexByName,
+  hasExclusionChars,
+} from './Util';
 
 export enum AnnotationColumnHeaderType {
   LEVEL,
@@ -58,6 +64,31 @@ export const ChangedAnnotationListItem = (props: {
   }
 
   const geneColumnIndex = getColumnIndexByName(annotationColumnHeader, GENE);
+  const mutationColumnIndex = getColumnIndexByName(
+    annotationColumnHeader,
+    MUTATION
+  );
+
+  if (mutationColumnIndex > -1 && geneColumnIndex > -1) {
+    // transform the gene and mutation input to a link, ignore the inputs with comma, pipe or slash
+    props.data.forEach(row => {
+      const geneInput = row.content[geneColumnIndex].content;
+      const mutationInput = row.content[mutationColumnIndex].content;
+      if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
+        if (
+          !hasExclusionChars(mutationInput) &&
+          !hasExclusionChars(geneInput)
+        ) {
+          row.content[
+            mutationColumnIndex
+          ].content = convertGeneAndAlterationInputToLink(
+            geneInput,
+            mutationInput
+          );
+        }
+      }
+    });
+  }
 
   if (geneColumnIndex > -1) {
     // transform the gene input to link(s)

--- a/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
@@ -74,7 +74,11 @@ export const ChangedAnnotationListItem = (props: {
     props.data.forEach(row => {
       const geneInput = row.content[geneColumnIndex].content;
       const mutationInput = row.content[mutationColumnIndex].content;
-      if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
+      if (
+        typeof geneInput === 'string' &&
+        typeof mutationInput === 'string' &&
+        geneInput !== 'ESR1'
+      ) {
         if (!hasExcludedChars(mutationInput) && !hasExcludedChars(geneInput)) {
           row.content[
             mutationColumnIndex

--- a/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
@@ -16,7 +16,7 @@ import {
   convertGeneInputToLinks,
   convertGeneAndAlterationInputToLink,
   getColumnIndexByName,
-  hasExclusionChars,
+  hasExcludedChars,
 } from './Util';
 
 export enum AnnotationColumnHeaderType {
@@ -75,10 +75,7 @@ export const ChangedAnnotationListItem = (props: {
       const geneInput = row.content[geneColumnIndex].content;
       const mutationInput = row.content[mutationColumnIndex].content;
       if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
-        if (
-          !hasExclusionChars(mutationInput) &&
-          !hasExclusionChars(geneInput)
-        ) {
+        if (!hasExcludedChars(mutationInput) && !hasExcludedChars(geneInput)) {
           row.content[
             mutationColumnIndex
           ].content = convertGeneAndAlterationInputToLink(

--- a/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/ChangedAnnotatonListItem.tsx
@@ -14,10 +14,10 @@ import _ from 'lodash';
 import mainStyle from './main.module.scss';
 import {
   convertGeneInputToLinks,
-  convertGeneAndAlterationInputToLink,
   getColumnIndexByName,
-  hasExcludedChars,
+  linkableMutationName,
 } from './Util';
+import { AlterationPageLink } from 'app/shared/utils/UrlUtils';
 
 export enum AnnotationColumnHeaderType {
   LEVEL,
@@ -74,17 +74,13 @@ export const ChangedAnnotationListItem = (props: {
     props.data.forEach(row => {
       const geneInput = row.content[geneColumnIndex].content;
       const mutationInput = row.content[mutationColumnIndex].content;
-      if (
-        typeof geneInput === 'string' &&
-        typeof mutationInput === 'string' &&
-        geneInput !== 'ESR1'
-      ) {
-        if (!hasExcludedChars(mutationInput) && !hasExcludedChars(geneInput)) {
-          row.content[
-            mutationColumnIndex
-          ].content = convertGeneAndAlterationInputToLink(
-            geneInput,
-            mutationInput
+      if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
+        if (linkableMutationName(geneInput, mutationInput)) {
+          row.content[mutationColumnIndex].content = (
+            <AlterationPageLink
+              hugoSymbol={geneInput}
+              alteration={mutationInput}
+            />
           );
         }
       }

--- a/src/main/webapp/app/pages/newsPage/NewsPageContent.tsx
+++ b/src/main/webapp/app/pages/newsPage/NewsPageContent.tsx
@@ -1090,7 +1090,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
       [
         '3A',
         'EGFR',
-        'Exon 20 insertion',
+        'Exon 20 in-frame insertions',
         'Non-Small Cell Lung Cancer',
         'CLN-081',
         <WithSeparator separator={EVIDENCE_COLUMN_SEPARATOR}>
@@ -1257,7 +1257,10 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
           ],
           [
             'MET',
-            'Y1003mut',
+            <AlterationPageLink hugoSymbol={'MET'} alteration={'Y1003'}>
+              {' '}
+              Y1003mut{' '}
+            </AlterationPageLink>,
             'Non-Small Cell Lung Cancer',
             'Tepotinib, Capmatinib',
             '1',
@@ -1283,7 +1286,10 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
           ],
           [
             'MET',
-            'Y1003mut',
+            <AlterationPageLink hugoSymbol={'MET'} alteration={'Y1003'}>
+              {' '}
+              Y1003mut{' '}
+            </AlterationPageLink>,
             'Non-Small Cell Lung Cancer',
             'Crizotinib',
             '2',
@@ -1683,7 +1689,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
         content: [
           [
             'EGFR',
-            'Exon 20 Insertions',
+            'Exon 20 in-frame insertions',
             'Non-Small Cell Lung Cancer',
             'Mobocertinib',
             '3A',
@@ -1784,7 +1790,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
           ],
           [
             'EGFR',
-            'Exon 20 Insertions',
+            'Exon 20 in-frame insertions',
             'Non-Small Cell Lung Cancer',
             'Amivantamab',
             '3A',
@@ -2034,7 +2040,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
       [
         '3A',
         'EGFR',
-        'Exon 20 Insertions',
+        'Exon 20 in-frame insertions',
         'Non-Small Cell Lung Cancer',
         'Mobocertinib',
         <PMIDLink pmids={'33632775'} />,
@@ -2042,7 +2048,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
       [
         '3A',
         'EGFR',
-        'Exon 20 Insertions',
+        'Exon 20 in-frame insertions',
         'Non-Small Cell Lung Cancer',
         'Amivantamab',
         <AbstractLink
@@ -2109,7 +2115,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
       [
         '1',
         'MET',
-        'Exon 14 Skipping Mutations',
+        'Exon 14 Deletion',
         'Non-Small Cell Lung Cancer',
         'Tepotinib',
         <WithSeparator separator={EVIDENCE_COLUMN_SEPARATOR}>
@@ -2651,7 +2657,9 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
                 <td>
                   <GenePageLink hugoSymbol={'BRAF'} />
                 </td>
-                <td>V600</td>
+                <td>
+                  <AlterationPageLink hugoSymbol={'BRAF'} alteration={'V600'} />
+                </td>
                 <td>Melanoma</td>
                 <td>Vemurafenib + Cobimetinib + Atezulizumab</td>
                 <td>
@@ -2670,7 +2678,12 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
                 <td rowSpan={3}>
                   <GenePageLink hugoSymbol={'PDGFRA'} />
                 </td>
-                <td rowSpan={3}>Oncogenic Mutations</td>
+                <td rowSpan={3}>
+                  <AlterationPageLink
+                    hugoSymbol={'PDGFRA'}
+                    alteration={'Oncogenic Mutations'}
+                  />
+                </td>
                 <td rowSpan={3}>Gastrointestinal Stromal Tumors</td>
                 <td>Ripretinib</td>
                 <td>
@@ -2724,7 +2737,12 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
       [
         '1',
         'Other Biomarkers',
-        'Tumor Mutational Burden - High',
+        <AlterationPageLink
+          hugoSymbol={'Other Biomarkers'}
+          alteration={'TMB-H'}
+        >
+          Tumor Mutational Burden - High
+        </AlterationPageLink>,
         'All Solid Tumors',
         'Pembrolizumab',
         <span>
@@ -2993,7 +3011,7 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
         content: [
           [
             'MET',
-            'Exon 14 Skipping Mutations',
+            'Exon 14 Deletion',
             'Non-Small Cell Lung Cancer',
             <div>Capmatinib</div>,
             '3A',

--- a/src/main/webapp/app/pages/newsPage/NewsPageContent.tsx
+++ b/src/main/webapp/app/pages/newsPage/NewsPageContent.tsx
@@ -40,7 +40,7 @@ import mainstyle from 'app/pages/newsPage/main.module.scss';
 import { PMALink } from 'app/shared/links/PMALink';
 import OptimizedImage from 'app/shared/image/OptimizedImage';
 import { AnnotationColumnHeaderType } from './ChangedAnnotatonListItem';
-import { hasExcludedChars } from './Util';
+import { linkableMutationName } from './Util';
 
 export type ChangedAnnotation = {
   content: ElementType[][];
@@ -4219,7 +4219,10 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
                   let content: ElementType = subItem;
                   if (subIndex === 0) {
                     content = <GenePageLink hugoSymbol={subItem} />;
-                  } else if (subIndex === 1 && !hasExcludedChars(subItem)) {
+                  } else if (
+                    subIndex === 1 &&
+                    linkableMutationName(geneInput, subItem)
+                  ) {
                     content = (
                       <AlterationPageLink
                         hugoSymbol={geneInput}

--- a/src/main/webapp/app/pages/newsPage/NewsPageContent.tsx
+++ b/src/main/webapp/app/pages/newsPage/NewsPageContent.tsx
@@ -40,6 +40,7 @@ import mainstyle from 'app/pages/newsPage/main.module.scss';
 import { PMALink } from 'app/shared/links/PMALink';
 import OptimizedImage from 'app/shared/image/OptimizedImage';
 import { AnnotationColumnHeaderType } from './ChangedAnnotatonListItem';
+import { hasExcludedChars } from './Util';
 
 export type ChangedAnnotation = {
   content: ElementType[][];
@@ -4193,15 +4194,21 @@ export const NEWS_BY_DATE: { [date: string]: NewsData } = {
           <SimpleTable
             columns={NEWLY_ADDED_LEVEL_FOUR_COLUMNS}
             rows={NEWLY_ADDED_LEVEL_FOUR.map((record, index) => {
+              const geneInput = record[0];
               return {
                 key: `NEWLY_ADDED_LEVEL_FOUR-${index}`,
                 content: record.map((subItem, subIndex) => {
-                  const content: ElementType =
-                    subIndex === 0 ? (
-                      <GenePageLink hugoSymbol={subItem} />
-                    ) : (
-                      subItem
+                  let content: ElementType = subItem;
+                  if (subIndex === 0) {
+                    content = <GenePageLink hugoSymbol={subItem} />;
+                  } else if (subIndex === 1 && !hasExcludedChars(subItem)) {
+                    content = (
+                      <AlterationPageLink
+                        hugoSymbol={geneInput}
+                        alteration={subItem}
+                      />
                     );
+                  }
                   return {
                     key: `NEWLY_ADDED_LEVEL_FOUR-${index}-${subIndex}`,
                     content,

--- a/src/main/webapp/app/pages/newsPage/UpdatedTxImplListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/UpdatedTxImplListItem.tsx
@@ -3,11 +3,8 @@ import { SimpleTable, SimpleTableRow } from 'app/components/SimpleTable';
 import { Row } from 'react-bootstrap';
 import React from 'react';
 import pluralize from 'pluralize';
-import {
-  convertGeneAndAlterationInputToLink,
-  convertGeneInputToLinks,
-  hasExcludedChars,
-} from './Util';
+import { convertGeneInputToLinks, linkableMutationName } from './Util';
+import { AlterationPageLink } from 'app/shared/utils/UrlUtils';
 
 export const UpdatedTxImplListItem = (props: {
   title?: string;
@@ -31,12 +28,12 @@ export const UpdatedTxImplListItem = (props: {
       const geneInput = row.content[geneColumnIndex].content;
       const mutationInput = row.content[mutationColumnIndex].content;
       if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
-        if (!hasExcludedChars(mutationInput) && !hasExcludedChars(geneInput)) {
-          row.content[
-            mutationColumnIndex
-          ].content = convertGeneAndAlterationInputToLink(
-            geneInput,
-            mutationInput
+        if (linkableMutationName(geneInput, mutationInput)) {
+          row.content[mutationColumnIndex].content = (
+            <AlterationPageLink
+              hugoSymbol={geneInput}
+              alteration={mutationInput}
+            />
           );
         }
       }

--- a/src/main/webapp/app/pages/newsPage/UpdatedTxImplListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/UpdatedTxImplListItem.tsx
@@ -6,7 +6,7 @@ import pluralize from 'pluralize';
 import {
   convertGeneAndAlterationInputToLink,
   convertGeneInputToLinks,
-  hasExclusionChars,
+  hasExcludedChars,
 } from './Util';
 
 export const UpdatedTxImplListItem = (props: {
@@ -31,10 +31,7 @@ export const UpdatedTxImplListItem = (props: {
       const geneInput = row.content[geneColumnIndex].content;
       const mutationInput = row.content[mutationColumnIndex].content;
       if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
-        if (
-          !hasExclusionChars(mutationInput) &&
-          !hasExclusionChars(geneInput)
-        ) {
+        if (!hasExcludedChars(mutationInput) && !hasExcludedChars(geneInput)) {
           row.content[
             mutationColumnIndex
           ].content = convertGeneAndAlterationInputToLink(

--- a/src/main/webapp/app/pages/newsPage/UpdatedTxImplListItem.tsx
+++ b/src/main/webapp/app/pages/newsPage/UpdatedTxImplListItem.tsx
@@ -3,7 +3,11 @@ import { SimpleTable, SimpleTableRow } from 'app/components/SimpleTable';
 import { Row } from 'react-bootstrap';
 import React from 'react';
 import pluralize from 'pluralize';
-import { convertGeneInputToLinks } from './Util';
+import {
+  convertGeneAndAlterationInputToLink,
+  convertGeneInputToLinks,
+  hasExclusionChars,
+} from './Util';
 
 export const UpdatedTxImplListItem = (props: {
   title?: string;
@@ -19,6 +23,29 @@ export const UpdatedTxImplListItem = (props: {
   )}`;
 
   const geneColumnIndex = 1;
+  const mutationColumnIndex = 2;
+
+  if (mutationColumnIndex > -1 && geneColumnIndex > -1) {
+    // transform the gene and mutation input to a link, ignore the inputs with comma, pipe or slash
+    props.data.forEach(row => {
+      const geneInput = row.content[geneColumnIndex].content;
+      const mutationInput = row.content[mutationColumnIndex].content;
+      if (typeof geneInput === 'string' && typeof mutationInput === 'string') {
+        if (
+          !hasExclusionChars(mutationInput) &&
+          !hasExclusionChars(geneInput)
+        ) {
+          row.content[
+            mutationColumnIndex
+          ].content = convertGeneAndAlterationInputToLink(
+            geneInput,
+            mutationInput
+          );
+        }
+      }
+    });
+  }
+
   // transform the gene input to a link
   props.data.forEach(row => {
     const geneInput = row.content[geneColumnIndex].content;

--- a/src/main/webapp/app/pages/newsPage/Util.tsx
+++ b/src/main/webapp/app/pages/newsPage/Util.tsx
@@ -1,14 +1,31 @@
 import React from 'react';
 import { ElementType } from 'app/components/SimpleTable';
-import { GenePageLink } from 'app/shared/utils/UrlUtils';
+import { AlterationPageLink, GenePageLink } from 'app/shared/utils/UrlUtils';
 import WithSeparator from 'react-with-separator';
 
 export const convertGeneInputToLinks = (geneInput: string): ElementType => {
-const itemLinks = geneInput.trim().split(',').map(token => (
-    <GenePageLink hugoSymbol={token.trim()}/>
-  ));
+  const itemLinks = geneInput
+    .trim()
+    .split(',')
+    .map(token => <GenePageLink hugoSymbol={token.trim()} />);
 
   return <WithSeparator separator=", ">{itemLinks}</WithSeparator>;
+};
+
+export const convertGeneAndAlterationInputToLink = (
+  geneInput: string,
+  alterationInput: string
+): ElementType => {
+  geneInput = geneInput.trim();
+  alterationInput = alterationInput.trim();
+  return (
+    <AlterationPageLink hugoSymbol={geneInput} alteration={alterationInput} />
+  );
+};
+
+export const hasExclusionChars = (input: string): boolean => {
+  const exclusionChars = [',', '|', '/'];
+  return exclusionChars.some(char => input.includes(char));
 };
 
 export const getColumnIndexByName = (

--- a/src/main/webapp/app/pages/newsPage/Util.tsx
+++ b/src/main/webapp/app/pages/newsPage/Util.tsx
@@ -16,7 +16,13 @@ export const linkableMutationName = (
   geneInput: string,
   mutationInput: string
 ): boolean => {
-  const excludedChars = [',', '|', '/'];
+  const excludedChars = [
+    ',',
+    '|',
+    '/',
+    'Oncogenic Ligand-Binding Domain Missense Mutations (310_547)',
+    'Oncogenic Ligand-Binding Domain In-Frame Insertions or Deletions (310_547)',
+  ];
   const geneInputHasExcludedChars = excludedChars.some(char =>
     geneInput.includes(char)
   );

--- a/src/main/webapp/app/pages/newsPage/Util.tsx
+++ b/src/main/webapp/app/pages/newsPage/Util.tsx
@@ -29,11 +29,7 @@ export const linkableMutationName = (
   const mutationInputHasExcludedChars = excludedChars.some(char =>
     mutationInput.includes(char)
   );
-  return (
-    !geneInputHasExcludedChars &&
-    !mutationInputHasExcludedChars &&
-    geneInput !== 'ESR1'
-  );
+  return !geneInputHasExcludedChars && !mutationInputHasExcludedChars;
 };
 
 export const getColumnIndexByName = (

--- a/src/main/webapp/app/pages/newsPage/Util.tsx
+++ b/src/main/webapp/app/pages/newsPage/Util.tsx
@@ -23,9 +23,9 @@ export const convertGeneAndAlterationInputToLink = (
   );
 };
 
-export const hasExclusionChars = (input: string): boolean => {
-  const exclusionChars = [',', '|', '/'];
-  return exclusionChars.some(char => input.includes(char));
+export const hasExcludedChars = (input: string): boolean => {
+  const excludedChars = [',', '|', '/'];
+  return excludedChars.some(char => input.includes(char));
 };
 
 export const getColumnIndexByName = (

--- a/src/main/webapp/app/pages/newsPage/Util.tsx
+++ b/src/main/webapp/app/pages/newsPage/Util.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ElementType } from 'app/components/SimpleTable';
-import { AlterationPageLink, GenePageLink } from 'app/shared/utils/UrlUtils';
+import { GenePageLink } from 'app/shared/utils/UrlUtils';
 import WithSeparator from 'react-with-separator';
 
 export const convertGeneInputToLinks = (geneInput: string): ElementType => {
@@ -12,20 +12,22 @@ export const convertGeneInputToLinks = (geneInput: string): ElementType => {
   return <WithSeparator separator=", ">{itemLinks}</WithSeparator>;
 };
 
-export const convertGeneAndAlterationInputToLink = (
+export const linkableMutationName = (
   geneInput: string,
-  alterationInput: string
-): ElementType => {
-  geneInput = geneInput.trim();
-  alterationInput = alterationInput.trim();
-  return (
-    <AlterationPageLink hugoSymbol={geneInput} alteration={alterationInput} />
-  );
-};
-
-export const hasExcludedChars = (input: string): boolean => {
+  mutationInput: string
+): boolean => {
   const excludedChars = [',', '|', '/'];
-  return excludedChars.some(char => input.includes(char));
+  const geneInputHasExcludedChars = excludedChars.some(char =>
+    geneInput.includes(char)
+  );
+  const mutationInputHasExcludedChars = excludedChars.some(char =>
+    mutationInput.includes(char)
+  );
+  return (
+    !geneInputHasExcludedChars &&
+    !mutationInputHasExcludedChars &&
+    geneInput !== 'ESR1'
+  );
 };
 
 export const getColumnIndexByName = (


### PR DESCRIPTION
the follow up PR for: https://github.com/oncokb/oncokb/issues/3414

if either entry input with `,|/` in `Gene` or `Mutation` columns, they are ignored.
so there is an alteration ink iff there is one gene and one mutation in its respective columns