### PR TITLE
Allow loading script from googletagmanager.com

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/SecurityConfiguration.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/SecurityConfiguration.java
@@ -69,7 +69,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .accessDeniedHandler(problemSupport)
         .and()
             .headers()
-            .contentSecurityPolicy("default-src 'self'; frame-src 'self' https://*.google.com https://www.recaptcha.net https://*.oncokb.org https://*.youtube.com https://*.bilibili.com https://*.gitbook.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/ https://storage.googleapis.com www.google-analytics.com https://recaptcha.net https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: www.google-analytics.com; font-src 'self' data:; connect-src 'self' https://*;")
+            .contentSecurityPolicy("default-src 'self'; frame-src 'self' https://*.google.com https://www.recaptcha.net https://*.oncokb.org https://*.youtube.com https://*.bilibili.com https://*.gitbook.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/ https://storage.googleapis.com www.google-analytics.com https://www.googletagmanager.com https://recaptcha.net https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: www.google-analytics.com; font-src 'self' data:; connect-src 'self' https://*;")
         .and()
             .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER_WHEN_DOWNGRADE)
         .and()


### PR DESCRIPTION
The website is used by google analytics 4.

This is related to https://github.com/oncokb/oncokb/issues/3412