### PR TITLE
Always show tx section in annotation page

### DIFF
--- a/src/main/webapp/app/pages/annotationPage/CancerTypeView.tsx
+++ b/src/main/webapp/app/pages/annotationPage/CancerTypeView.tsx
@@ -185,15 +185,13 @@ const FdaView: React.FunctionComponent<{
 export const CancerTypeView: React.FunctionComponent<ICancerTypeView> = props => {
   return (
     <div className={'mt-3'}>
-      {props.therapeuticImplications.length > 0 && (
-        <TxView
-          isLargeScreen={props.isLargeScreen}
-          userAuthenticated={props.userAuthenticated}
-          hugoSymbol={props.hugoSymbol}
-          summary={props.annotation.tumorTypeSummary}
-          implications={props.therapeuticImplications}
-        />
-      )}
+      <TxView
+        isLargeScreen={props.isLargeScreen}
+        userAuthenticated={props.userAuthenticated}
+        hugoSymbol={props.hugoSymbol}
+        summary={props.annotation.tumorTypeSummary}
+        implications={props.therapeuticImplications}
+      />
       {props.diagnosticImplications.length > 0 && (
         <DxPxView
           isLargeScreen={props.isLargeScreen}


### PR DESCRIPTION
We have tumor type summary designed for cases without any treatment, example: JAK2/OncogenicMutations/Other Tumor Type. We should show the summary even when tx is not applicable.