### PR TITLE
Keep annotation source logo on the same line of text

### DIFF
--- a/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
@@ -498,7 +498,7 @@ export default class AnnotationPage extends React.Component<
     return (
       <>
         <div className={'d-flex justify-content-between flex-wrap'}>
-          <div>
+          <div style={{ flex: '1 1 300px' }}>
             <h2
               className={'d-flex align-items-baseline flex-wrap'}
               style={{ marginBottom: 0 }}


### PR DESCRIPTION
We will try to keep the logo in the same line by shrinking the text on the left until it reaches minimum 300px.

This fixes https://github.com/oncokb/oncokb/issues/3537