### PR TITLE
Add link to alteration page in the mutation effect description

### DIFF
--- a/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/AnnotationPage.tsx
@@ -78,6 +78,7 @@ import { Else, If, Then } from 'react-if';
 import { UnknownGeneAlert } from 'app/shared/alert/UnknownGeneAlert';
 import { RouterStore } from 'mobx-react-router';
 import { Option } from 'app/shared/select/FormSelectWithLabelField';
+import MutationEffectDescription from 'app/pages/annotationPage/MutationEffectDescription';
 
 export enum AnnotationType {
   GENE,
@@ -601,12 +602,12 @@ export default class AnnotationPage extends React.Component<
                 show={this.showMutationEffect}
                 title="mutation effect description"
                 content={
-                  <SummaryWithRefs
-                    content={
+                  <MutationEffectDescription
+                    hugoSymbol={this.props.store.hugoSymbol}
+                    description={
                       this.props.store.annotationData.result.mutationEffect
                         .description
                     }
-                    type="linkout"
                   />
                 }
                 onClick={() =>

--- a/src/main/webapp/app/pages/annotationPage/MutationEffectDescription.tsx
+++ b/src/main/webapp/app/pages/annotationPage/MutationEffectDescription.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { AlterationPageLink } from 'app/shared/utils/UrlUtils';
+import WithSeparator from 'react-with-separator';
+import SummaryWithRefs from 'app/oncokb-frontend-commons/src/components/SummaryWithRefs';
+
+const MutationEffectDescription: React.FunctionComponent<{
+  hugoSymbol: string;
+  description: string | undefined;
+}> = props => {
+  // Add link to alteration page when the allele is unknown but multiple alternative alleles at the same position have mutation effects
+  const description = props.description || '';
+  const addlMeSeparator = 'however, we have mutation effect descriptions for';
+  if (description.includes(addlMeSeparator)) {
+    const segments = description.split(addlMeSeparator);
+    if (segments.length === 2) {
+      // supposedly the last word is the alteration
+      const varSegs = segments[1].split(' ');
+      let alterationStr = varSegs.pop();
+      if (alterationStr) {
+        const altRegex = new RegExp('([A-Z]+[0-9]+)([A-Z]+(/[A-Z]+)*)', 'i');
+        alterationStr = alterationStr.replace('.', '');
+        if (altRegex.test(alterationStr)) {
+          const matches = altRegex.exec(alterationStr);
+          if (matches) {
+            const positionalVar = matches[1];
+            const alternativeAlleles = matches[2];
+            const alleleLines = alternativeAlleles
+              .split('/')
+              .map((allele, index) => {
+                return (
+                  <AlterationPageLink
+                    hugoSymbol={props.hugoSymbol}
+                    alteration={`${positionalVar}${allele}`}
+                  >
+                    {index === 0 ? `${positionalVar}${allele}` : allele}
+                  </AlterationPageLink>
+                );
+              });
+            return (
+              <span>
+                {segments[0]} {addlMeSeparator}
+                {varSegs.join(' ')}{' '}
+                <WithSeparator separator={'/'}>{alleleLines}</WithSeparator>.
+              </span>
+            );
+          }
+        }
+      }
+    }
+  }
+  // don't do anything but add reference links in the description
+  return <SummaryWithRefs content={props.description} type="linkout" />;
+};
+
+export default MutationEffectDescription;

--- a/src/main/webapp/app/pages/annotationPage/MutationEffectDescription.tsx
+++ b/src/main/webapp/app/pages/annotationPage/MutationEffectDescription.tsx
@@ -9,9 +9,10 @@ const MutationEffectDescription: React.FunctionComponent<{
 }> = props => {
   // Add link to alteration page when the allele is unknown but multiple alternative alleles at the same position have mutation effects
   const description = props.description || '';
-  const addlMeSeparator = 'however, we have mutation effect descriptions for';
-  if (description.includes(addlMeSeparator)) {
-    const segments = description.split(addlMeSeparator);
+  const additionalMutationEffectSeparator =
+    'however, we have mutation effect descriptions for';
+  if (description.includes(additionalMutationEffectSeparator)) {
+    const segments = description.split(additionalMutationEffectSeparator);
     if (segments.length === 2) {
       // supposedly the last word is the alteration
       const varSegs = segments[1].split(' ');
@@ -38,7 +39,7 @@ const MutationEffectDescription: React.FunctionComponent<{
               });
             return (
               <span>
-                {segments[0]} {addlMeSeparator}
+                {segments[0]} {additionalMutationEffectSeparator}
                 {varSegs.join(' ')}{' '}
                 <WithSeparator separator={'/'}>{alleleLines}</WithSeparator>.
               </span>


### PR DESCRIPTION
when the allele is unknown but multiple alternative alleles at the same position have mutation effects

This fixes https://github.com/oncokb/oncokb/issues/3552