### PR TITLE
Change extra large cutoff based on the header items

### DIFF
--- a/src/main/webapp/app/variables.scss
+++ b/src/main/webapp/app/variables.scss
@@ -31,7 +31,7 @@ $grid-breakpoints: (
   sm: 576px,
   md: 768px,
   lg: 1050px,
-  xl: 1500px,
+  xl: 1413px,
 ) !default;
 
 // we only need to define the max width for xl, smaller size will use the fluid width.


### PR DESCRIPTION
We originally have Precision Oncology Therapies which has been changed to Oncology Therapies. The new headers will only be converted to two lines at 1413px