### PR TITLE
Use official sentry github action

### DIFF
--- a/.github/workflows/docker-sentry-release.yml
+++ b/.github/workflows/docker-sentry-release.yml
@@ -36,23 +36,23 @@ jobs:
           -Djib.to.auth.username=$DOCKER_USERNAME \
           -Djib.to.auth.password=$DOCKER_PASSWORD
       - name: Create a Sentry.io release in oncokb-public-website
-        uses: tclindner/sentry-releases-action@v1.2.0
+        uses: getsentry/action-release@v1.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: memorial-sloan-kettering
           SENTRY_PROJECT: oncokb-public-website
         with:
-          tagName: ${{ github.ref }}
+          version: ${{ github.ref }}
           environment: production
-          releaseNamePrefix: oncokb-public-
+          version_prefix: oncokb-public-
           sourceMapOptions: '{"include": ["target/classes/static/app"]}'
       - name: Create a Sentry.io release in oncokb-public-website-backend
-        uses: tclindner/sentry-releases-action@v1.2.0
+        uses: getsentry/action-release@v1.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: memorial-sloan-kettering
           SENTRY_PROJECT: oncokb-public-website-backend
         with:
-          tagName: ${{ github.ref }}
+          version: ${{ github.ref }}
           environment: production
-          releaseNamePrefix: oncokb-public-backend-
+          version_prefix: oncokb-public-backend-


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3723


### Changes:
1. Use official sentry github action
2. Update `releaseNamePrefix` and `tagName` parameters to corresponding names in the official sentry action: `version_prefix` and `version`. Refer to https://github.com/getsentry/action-release?tab=readme-ov-file#parameters

I tested these changes on my fork: https://github.com/calvinlu3/oncokb-public/actions/runs/8637933444/job/23681240882
    - The step labeled `Create a Sentry.io release in oncokb-public-test` is now passing
    - Verified that the Sentry release is available on Sentry.io 

