### PR TITLE
Fixed broken canonical link

### DIFF
--- a/src/main/webapp/app/shared/route/OncokbRoute.tsx
+++ b/src/main/webapp/app/shared/route/OncokbRoute.tsx
@@ -12,7 +12,7 @@ function CanonicalLink({ routeProps }: CanonicalLinkProps) {
     linkNode.setAttribute('rel', 'canonical');
     linkNode.setAttribute(
       'href',
-      `${location.protocol}${location.host}${canonicalEndpoint}`
+      `${location.protocol}//${location.host}${canonicalEndpoint}`
     );
 
     document.head.appendChild(linkNode);


### PR DESCRIPTION
The canonical link was broken so I think that's why validation failed. I also checked if we're making these [common mistakes](https://developers.google.com/search/blog/2013/04/5-common-mistakes-with-relcanonical) and I do not think we are.