### PR TITLE
Update reference regex to support 1 level of nested parenthesis

### DIFF
--- a/src/main/webapp/app/config/constants/regex.spec.ts
+++ b/src/main/webapp/app/config/constants/regex.spec.ts
@@ -32,6 +32,15 @@ describe('Regex constants test', () => {
       expect(REF_CAPTURE.test(`test ( ${abstractContent} )`)).toBeTruthy();
       expect(REF_CAPTURE.test(`test ( ${abstractContent}`)).toBeFalsy();
     });
+
+    it('should handle abstracts with one level of nested parenthesis in url', () => {
+      expect(
+        REF_CAPTURE.test(
+          '(Abstract: Solomon, BJ. Abstract #1372P, Annals of Oncology Vol 34, Suppl 2. https://www.annalsofoncology.org/article/S0923-7534(23)03242-8/fulltext)'
+        )
+      ).toEqual(true);
+    });
+
     it('Regex should capture expected matches', () => {
       const mixText =
         'A statistically (significant) hotspot (PMID: 23525077). To wildtype (Abstract: Zeng et al. Abstract #0177, IDDF 2020.). Preclinical st(udie)s suggest.';

--- a/src/main/webapp/app/config/constants/regex.ts
+++ b/src/main/webapp/app/config/constants/regex.ts
@@ -2,4 +2,4 @@
 //     (PMID: 11900253)
 //     (PMID: 11753428, 16007150, 21467160)
 //     (NCT1234567)
-export const REF_CAPTURE = /(\(\s*(?:PMID|NCT|Abstract):?.*?\))/i;
+export const REF_CAPTURE = /(\(\s*(?:PMID|NCT|Abstract):?.*?(?:\([^()]*\).*?)*\))/i;


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb-pipeline/issues/359