### PR TITLE
Fix FDA recognition letter linkout

### DIFF
--- a/src/main/webapp/app/pages/aboutGroup/FdaRecognitionPage.tsx
+++ b/src/main/webapp/app/pages/aboutGroup/FdaRecognitionPage.tsx
@@ -102,7 +102,7 @@ const FdaRecognitionPage = () => {
             <ul>
               <li>
                 <Linkout
-                  link={`content/files/fdaRecognition/OncoKB_FDA_Recognition_Recognition_Letter.pdf`}
+                  link={`${window.location.origin}/content/files/fdaRecognition/OncoKB_FDA_Recognition_Recognition_Letter.pdf`}
                 >
                   FDA Recognition Letter
                 </Linkout>


### PR DESCRIPTION
This is a linkout URL which needs to include the origin.

This fixes https://github.com/oncokb/oncokb/issues/3765