### PR TITLE
Do not reload the page when authentication endpoint failed

### DIFF
--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -609,6 +609,10 @@ export enum PAGE_ROUTE {
   ACCOUNT_ACTIVE_TRIAL_FINISH = '/account/active-trial/finish',
 }
 
+export enum API_ROUTE {
+  AUTHENTICATE = '/api/authenticate',
+}
+
 export enum TABLE_COLUMN_KEY {
   HUGO_SYMBOL = 'HUGO_SYMBOL',
   ALTERATION = 'ALTERATION',

--- a/src/main/webapp/app/index.tsx
+++ b/src/main/webapp/app/index.tsx
@@ -23,7 +23,7 @@ import {
   getPublicWebsiteToken,
   getStoredRecaptchaToken,
 } from 'app/indexUtils';
-import { UNAUTHORIZED_ALLOWED_PATH } from 'app/config/constants';
+import { API_ROUTE, UNAUTHORIZED_ALLOWED_PATH } from 'app/config/constants';
 import { AppConfig, AppProfile } from 'app/appConfig';
 
 assignPublicToken();
@@ -79,6 +79,8 @@ superagent.Request.prototype.end = function (callback) {
       AppConfig.serverConfig.token &&
       AppConfig.serverConfig.appProfile === AppProfile.PROD &&
       response.req &&
+      // we do not reload the page when the /api/authenticate failed
+      response.req.url !== API_ROUTE.AUTHENTICATE &&
       UNAUTHORIZED_ALLOWED_PATH.some(path =>
         window.location.pathname.endsWith(path)
       )


### PR DESCRIPTION
We try to reload the page when we see 401 code so user can use server side returned token. However, in login page, the /api/authentication api will return 401 when a token is expired. Here in this fix, we white list the API from being reloaded.

This fixes https://github.com/oncokb/oncokb/issues/3785