### PR TITLE
Added mock email server

### DIFF
--- a/src/main/docker/smtp-server.yml
+++ b/src/main/docker/smtp-server.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  fake-smtp-server:
+    image: gessnerfl/fake-smtp-server:2.2.1
+    hostname: 'fake-smtp-server'
+    restart: always
+    environment:
+      - FAKESMTP_AUTHENTICATION_USERNAME=myuser
+      - FAKESMTP_AUTHENTICATION_PASSWORD=mysecretpassword
+    ports:
+      - 8025:8025 #expose smtp port
+      - 8082:8080 #expose web ui
+      - 8081:8081 #expose management api

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -55,16 +55,16 @@ spring:
     # Remove 'faker' if you do not want the sample data to be loaded automatically
     contexts: dev, faker
   mail:
-    host: smtp.gmail.com
-    username:
-    password:
-    port: 587
+    host: localhost
+    username: myuser
+    password: mysecretpassword
+    port: 8025
     protocol: smtp
-    tls: true
+    tls: false
     properties.mail.smtp:
       auth: true
-      starttls.enable: true
-      ssl.trust: smtp.gmail.com
+      starttls.enable: false
+      ssl.trust:
   messages:
     cache-duration: PT1S # 1 second, see the ISO 8601 standard
   thymeleaf:


### PR DESCRIPTION
closes oncokb/oncokb-pipeline#535

This [mock server](https://github.com/gessnerfl/fake-smtp-server) just captures the email requests and gives you a UI to see what was sent.