### PR TITLE
Ignore TokenExpiredException in Sentry

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/OncokbPublicApp.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/OncokbPublicApp.java
@@ -106,6 +106,7 @@ public class OncokbPublicApp {
                 options.addIgnoredExceptionForType(CustomMessageRuntimeException.class);
                 options.addIgnoredExceptionForType(BadRequestAlertException.class);
                 options.addIgnoredExceptionForType(ResourceAccessException.class);
+                options.addIgnoredExceptionForType(TokenExpiredException.class);
             });
         }
     }


### PR DESCRIPTION
Resolves https://github.com/oncokb/oncokb/issues/3866

No need to catch this exception in Sentry. It is for the user