### PR TITLE
Fix Verify Email Link Not Working

### DIFF
--- a/src/main/resources/templates/mail/activationEmail.html
+++ b/src/main/resources/templates/mail/activationEmail.html
@@ -13,7 +13,8 @@
             Your OncoKB account has been created. Please click the URL below to verify your email address:
         </p>
         <p>
-            <a th:with="url=(@{|${baseUrl}/account/verify?key=${user.activationKey}&login=${user.login}|})" th:href="${url}"
+            <a th:with="verifyUrl=${baseUrl} + '/account/verify',
+              url=(@{${verifyUrl}(key=${user.activationKey},login=${user.login})})" th:href="${url}"
             th:text="${url}">Verification link</a>
         </p>
         <p>

--- a/src/main/resources/templates/mail/verifyEmailBeforeAccountExpires.html
+++ b/src/main/resources/templates/mail/verifyEmailBeforeAccountExpires.html
@@ -13,7 +13,8 @@
             Your OncoKB account will expire in <span th:text="${expiresInDays}"></span> days. Please click the URL below to verify you still own this email address and to renew your account:
         </p>
         <p>
-            <a th:with="url=(@{|${baseUrl}/account/verify?key=${user.activationKey}&login=${user.login}|})" th:href="${url}"
+            <a th:with="verifyUrl=${baseUrl} + '/account/verify',
+              url=(@{${verifyUrl}(key=${user.activationKey},login=${user.login})})" th:href="${url}"
             th:text="${url}">Verification link</a>
         </p>
         <p>

--- a/src/main/webapp/app/pages/userPage/UserPage.tsx
+++ b/src/main/webapp/app/pages/userPage/UserPage.tsx
@@ -619,7 +619,9 @@ export default class UserPage extends React.Component<IUserPage> {
                             <QuickToolButton
                               onClick={() =>
                                 this.props.routing.history.push(
-                                  `${PAGE_ROUTE.ADMIN_SEND_EMAILS}?to=${this.user.email}`
+                                  `${
+                                    PAGE_ROUTE.ADMIN_SEND_EMAILS
+                                  }?to=${encodeURIComponent(this.user.email)}`
                                 )
                               }
                             >


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/901

Some users had links with `+` in their email. This was breaking our validation link because this is treated as a space in URL encoding. I updated our email templates so that the email is URL encoded. I noticed a similar issue with a link in our admin pages.