### PR TITLE
Fixed grace period users not being able to log in

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserUUIDController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserUUIDController.java
@@ -2,10 +2,12 @@ package org.mskcc.cbio.oncokb.web.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.mskcc.cbio.oncokb.domain.Token;
+import org.mskcc.cbio.oncokb.security.SecurityUtils;
 import org.mskcc.cbio.oncokb.security.uuid.UUIDFilter;
 import org.mskcc.cbio.oncokb.security.uuid.TokenProvider;
 import org.mskcc.cbio.oncokb.service.TokenService;
 import org.mskcc.cbio.oncokb.service.UserDetailsService;
+import org.mskcc.cbio.oncokb.service.UserService;
 import org.mskcc.cbio.oncokb.service.dto.UserDetailsDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.Activation;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +55,9 @@ public class UserUUIDController {
     @Autowired
     private UserDetailsService userDetailsService;
 
+    @Autowired
+    private UserService userService;
+
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     public UserUUIDController(TokenProvider tokenProvider, AuthenticationManagerBuilder authenticationManagerBuilder) {
@@ -68,26 +74,26 @@ public class UserUUIDController {
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
+        Optional<UserDetailsDTO> userDetails = userDetailsService.findByUserIsCurrentUser();
         List<Token> tokenList = tokenService.findByUserIsCurrentUser();
         UUID uuid;
 
-        if (tokenList.size() > 0) {
+        if (!tokenList.isEmpty()) {
             List<Token> validTokens = tokenList.stream().filter(token -> token.getExpiration().isAfter(Instant.now())).collect(Collectors.toList());
-            if (validTokens.size() > 0) {
+            if (!validTokens.isEmpty()) {
                 uuid = validTokens.iterator().next().getToken();
+            } else if (canRefreshExpiredTokenForCurrentGracePeriodUser(userDetails)) {
+                uuid = refreshExpiredTokens(tokenList);
+            } else if (tokenList.stream().noneMatch(Token::isRenewable)) {
+                throw new TrialAccountExpiredException();
             } else {
-                if (!tokenList.stream().filter(token -> token.isRenewable()).findAny().isPresent()) {
-                    throw new TrialAccountExpiredException();
-                } else {
-                    throw new TokenExpiredException();
-                }
+                throw new TokenExpiredException();
             }
         } else {
             Token token = tokenProvider.createTokenForCurrentUserLogin(Optional.empty(), Optional.empty());
             uuid = token.getToken();
         }
 
-        Optional<UserDetailsDTO> userDetails = userDetailsService.findByUserIsCurrentUser();
         if (userDetails.isPresent()) {
             UserDetailsDTO ud = userDetails.get();
             boolean userHasTrialKey = Optional.ofNullable(ud)
@@ -112,5 +118,28 @@ public class UserUUIDController {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(UUIDFilter.AUTHORIZATION_HEADER, "Bearer " + uuid);
         return new ResponseEntity<>(uuid, httpHeaders, HttpStatus.OK);
+    }
+
+    private boolean canRefreshExpiredTokenForCurrentGracePeriodUser(Optional<UserDetailsDTO> userDetails) {
+        return userService.getUserWithAuthorities()
+            .filter(user -> !user.getActivated())
+            .flatMap(user -> userDetails
+                .map(UserDetailsDTO::getLicenseType)
+                .filter(licenseType -> SecurityUtils.isWithinActivationGracePeriod(user, licenseType)))
+            .isPresent();
+    }
+
+    private UUID refreshExpiredTokens(List<Token> tokenList) {
+        Instant defaultExpiration = Instant.now().plusSeconds(TokenProvider.EXPIRATION_TIME_IN_SECONDS);
+        tokenList.forEach(token -> {
+            Instant expirationBased = token.getExpiration().plusSeconds(TokenProvider.EXPIRATION_TIME_IN_SECONDS);
+            token.setExpiration(expirationBased.isBefore(defaultExpiration) ? defaultExpiration : expirationBased);
+            tokenService.save(token);
+        });
+
+        return tokenList.stream()
+            .max(Comparator.comparing(Token::getExpiration))
+            .map(Token::getToken)
+            .orElseThrow(TokenExpiredException::new);
     }
 }

--- a/src/test/java/org/mskcc/cbio/oncokb/web/rest/UserUUIDControllerIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/web/rest/UserUUIDControllerIT.java
@@ -1,11 +1,17 @@
 package org.mskcc.cbio.oncokb.web.rest;
 
 import org.mskcc.cbio.oncokb.OncokbPublicApp;
+import org.mskcc.cbio.oncokb.domain.Authority;
+import org.mskcc.cbio.oncokb.domain.Token;
 import org.mskcc.cbio.oncokb.domain.User;
 import org.mskcc.cbio.oncokb.domain.UserDetails;
 import org.mskcc.cbio.oncokb.domain.enumeration.AccountRequestStatus;
+import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
+import org.mskcc.cbio.oncokb.repository.AuthorityRepository;
 import org.mskcc.cbio.oncokb.repository.UserDetailsRepository;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
+import org.mskcc.cbio.oncokb.security.AuthoritiesConstants;
+import org.mskcc.cbio.oncokb.service.TokenService;
 import org.mskcc.cbio.oncokb.web.rest.vm.LoginVM;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -16,11 +22,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
@@ -34,7 +47,13 @@ public class UserUUIDControllerIT {
     private UserRepository userRepository;
 
     @Autowired
+    private AuthorityRepository authorityRepository;
+
+    @Autowired
     private UserDetailsRepository userDetailsRepository;
+
+    @Autowired
+    private TokenService tokenService;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -78,5 +97,61 @@ public class UserUUIDControllerIT {
                     .content(TestUtil.convertObjectToJsonBytes(loginVM)))
                 .andExpect(status().isUnauthorized());
         }
+    }
+
+    @Test
+    @Transactional
+    public void testGracePeriodUserCanRefreshExpiredTokenOnLogin() throws Exception {
+        String login = "pending.grace.user";
+        String rawPassword = "password";
+
+        User user = new User();
+        user.setLogin(login);
+        user.setEmail("pending.grace.user@example.com");
+        user.setFirstName("Pending");
+        user.setLastName("Grace");
+        user.setLangKey("en");
+        user.setActivated(false);
+        user.setActivationKey(null);
+        user.setCreatedDate(Instant.now());
+        user.setPassword(passwordEncoder.encode(rawPassword));
+        Authority userAuthority = authorityRepository.findById(AuthoritiesConstants.USER)
+            .orElseThrow(() -> new IllegalStateException("Missing ROLE_USER authority"));
+        user.setAuthorities(Collections.singleton(userAuthority));
+        user = userRepository.save(user);
+
+        UserDetails userDetails = new UserDetails();
+        userDetails.setUser(user);
+        userDetails.setAccountRequestStatus(AccountRequestStatus.PENDING);
+        userDetails.setLicenseType(LicenseType.COMMERCIAL);
+        userDetailsRepository.save(userDetails);
+
+        Token expiredToken = new Token();
+        expiredToken.setUser(user);
+        expiredToken.setToken(UUID.randomUUID());
+        expiredToken.setCreation(Instant.now().minusSeconds(3600));
+        expiredToken.setExpiration(Instant.now().minusSeconds(60));
+        expiredToken.setRenewable(true);
+        tokenService.save(expiredToken);
+
+        LoginVM loginVM = new LoginVM();
+        loginVM.setUsername(login);
+        loginVM.setPassword(rawPassword);
+        loginVM.setRememberMe(false);
+
+        MvcResult result = restMockMvc.perform(post("/api/authenticate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtil.convertObjectToJsonBytes(loginVM)))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Authorization", containsString("Bearer ")))
+            .andReturn();
+
+        Token refreshedToken = tokenService.findByUser(user).stream()
+            .filter(token -> token.getId().equals(expiredToken.getId()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Expired token was not refreshed"));
+
+        assertThat(refreshedToken.getExpiration()).isAfter(Instant.now());
+        assertThat(result.getResponse().getContentAsString()).isEqualTo("\"" + refreshedToken.getToken() + "\"");
     }
 }


### PR DESCRIPTION
Updates /api/authenticate so users still within the activation grace period can get a refreshed token when their previous renewable token has expired, instead of being blocked by `TokenExpiredException`.

closes https://github.com/oncokb/oncokb-pipeline/issues/1161