### PR TITLE
Add content transfer encoding to emails and add manual key verification

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/MailService.java
@@ -134,6 +134,7 @@ public class MailService {
         }
         message.setSubject(subject);
         message.setText(content, isHtml);
+        mimeMessage.setHeader("Content-Transfer-Encoding", "base64");
 
         if (attachmentFilesNames != null) {
             attachmentFilesNames.forEach(filename -> {

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -156,6 +156,7 @@ public class AccountResource {
         UserDetailsDTO existingUserDetails = userDetailsService.findOneByUser(existingUser)
             .orElseThrow(() -> new CustomMessageRuntimeException("User details could not be found"));
         boolean hasGracePeriod = AccountRequestStatus.PENDING.equals(existingUserDetails.getAccountRequestStatus())
+            && existingUserDetails.getLicenseType() != null
             && SecurityUtils.isWithinActivationGracePeriod(existingUser, existingUserDetails.getLicenseType());
         boolean newUserActivation = !existingUser.getActivated();
 

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/AccountResource.java
@@ -5,6 +5,7 @@ import org.mskcc.cbio.oncokb.domain.Company;
 import org.mskcc.cbio.oncokb.domain.CompanyCandidate;
 import org.mskcc.cbio.oncokb.domain.Token;
 import org.mskcc.cbio.oncokb.domain.User;
+import org.mskcc.cbio.oncokb.domain.enumeration.AccountRequestStatus;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseStatus;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
@@ -145,46 +146,44 @@ public class AccountResource {
      * @throws RuntimeException {@code 500 (Internal Server Error)} if the user couldn't be activated.
      */
     @GetMapping("/activate")
-    public boolean activateAccount(@RequestParam(value = "key") String key, @RequestParam(value = "login") String login) {
-        Optional<User> userOptional = userService.getUserByLogin(login);
-        if (!userOptional.isPresent() || (userOptional.get().getActivationKey() != null && !userOptional.get().getActivationKey().equals(key))) {
-            throw new CustomMessageRuntimeException("Your user account could not be activated as no user was found associated with this activation key.");
-        } else {
-            if (userOptional.get().getActivationKey() == null) {
-                return userOptional.get().getActivated();
-            }
-
-            boolean newUserActivation = !userOptional.get().getActivated();
-            userOptional = userService.activateRegistration(key);
-
-            User user;
-            if (userOptional.isPresent()) {
-                user = userOptional.get();
-            } else {
-                throw new CustomMessageRuntimeException("User could not be found");
-            }
-
-            if (newUserActivation) {
-                UserDTO userDTO = userMapper.userToUserDTO(user);
-                return activateUser(userDTO, userService.findCompanyCandidate(userDTO));
-            } else {
-                // This user exists before, we are looking for to extend the expiration date of all tokens associated
-                List<Token> userTokens = tokenService.findByUser(user);
-                boolean userAccountCanNOTBeExtended = !userTokens.stream().filter(token -> token.isRenewable()).findAny().isPresent();
-                if (userAccountCanNOTBeExtended) {
-                    throw new CustomMessageRuntimeException("Your account token is expired and cannot be extended.");
-                } else {
-                    Instant defaultExpiration = Instant.now().plusSeconds(tokenProvider.EXPIRATION_TIME_IN_SECONDS);
-                    tokenService.findByUser(user).forEach(token -> {
-                        // if the extended date based on the current token expiration is before the date in 6month, we should use the bigger one
-                        Instant expirationBased = token.getExpiration().plusSeconds(tokenProvider.EXPIRATION_TIME_IN_SECONDS);
-                        token.setExpiration(expirationBased.isBefore(defaultExpiration) ? defaultExpiration : expirationBased);
-                        tokenService.save(token);
-                    });
-                }
-            }
-            return true;
+    public AccountActivationVM activateAccount(@RequestParam(value = "key") String key) {
+        Optional<User> userOptional = userService.getUserByActivationKey(key);
+        if (!userOptional.isPresent()) {
+            throw new CustomMessageRuntimeException("Your account could not be activated because the activation key is invalid or has already been used.");
         }
+
+        User existingUser = userOptional.get();
+        UserDetailsDTO existingUserDetails = userDetailsService.findOneByUser(existingUser)
+            .orElseThrow(() -> new CustomMessageRuntimeException("User details could not be found"));
+        boolean hasGracePeriod = AccountRequestStatus.PENDING.equals(existingUserDetails.getAccountRequestStatus())
+            && SecurityUtils.isWithinActivationGracePeriod(existingUser, existingUserDetails.getLicenseType());
+        boolean newUserActivation = !existingUser.getActivated();
+
+        userOptional = userService.activateRegistration(key);
+        User user = userOptional.orElseThrow(() -> new CustomMessageRuntimeException("User could not be found"));
+
+        boolean activated;
+        if (newUserActivation) {
+            UserDTO userDTO = userMapper.userToUserDTO(user);
+            activated = activateUser(userDTO, userService.findCompanyCandidate(userDTO));
+        } else {
+            // This user exists before, we are looking to extend the expiration date of all tokens associated
+            List<Token> userTokens = tokenService.findByUser(user);
+            boolean userAccountCanNOTBeExtended = !userTokens.stream().filter(token -> token.isRenewable()).findAny().isPresent();
+            if (userAccountCanNOTBeExtended) {
+                throw new CustomMessageRuntimeException("Your account token is expired and cannot be extended.");
+            }
+            Instant defaultExpiration = Instant.now().plusSeconds(tokenProvider.EXPIRATION_TIME_IN_SECONDS);
+            tokenService.findByUser(user).forEach(token -> {
+                // if the extended date based on the current token expiration is before the date in 6month, we should use the bigger one
+                Instant expirationBased = token.getExpiration().plusSeconds(tokenProvider.EXPIRATION_TIME_IN_SECONDS);
+                token.setExpiration(expirationBased.isBefore(defaultExpiration) ? defaultExpiration : expirationBased);
+                tokenService.save(token);
+            });
+            activated = true;
+        }
+
+        return new AccountActivationVM(activated, hasGracePeriod);
     }
 
     private boolean activateUser(

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/vm/AccountActivationVM.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/vm/AccountActivationVM.java
@@ -1,0 +1,19 @@
+package org.mskcc.cbio.oncokb.web.rest.vm;
+
+public class AccountActivationVM {
+    private boolean activated;
+    private boolean hasGracePeriod;
+
+    public AccountActivationVM(boolean activated, boolean hasGracePeriod) {
+        this.activated = activated;
+        this.hasGracePeriod = hasGracePeriod;
+    }
+
+    public boolean isActivated() {
+        return activated;
+    }
+
+    public boolean isHasGracePeriod() {
+        return hasGracePeriod;
+    }
+}

--- a/src/main/resources/templates/mail/activationEmail.html
+++ b/src/main/resources/templates/mail/activationEmail.html
@@ -13,9 +13,14 @@
             Your OncoKB account has been created. Please click the URL below to verify your email address:
         </p>
         <p>
-            <a th:with="verifyUrl=${baseUrl} + '/account/verify',
-              url=(@{${verifyUrl}(key=${user.activationKey},login=${user.login},hasGracePeriod=${hasGracePeriod})})" th:href="${url}"
+            <a th:with="url=(@{|${baseUrl}/account/verify?key=${user.activationKey}|})" th:href="${url}"
             th:text="${url}">Verification link</a>
+        </p>
+        <p>
+            If the link above does not work, you can verify your email manually by visiting <a th:with="url=(@{|${baseUrl}/account/verify|})" th:href="${url}" th:text="${url}">verification page</a> and entering the activation key below:
+        </p>
+        <p style="text-align: center;">
+            <strong th:text="${user.activationKey}">activation-key</strong>
         </p>
         <p th:if="${hasGracePeriod}">
           After validating your email address, you will be able to access the OncoKB website. In parallel, your request will be reviewed on an individual basis, and you may be contacted with follow-up questions.

--- a/src/main/resources/templates/mail/verifyEmailBeforeAccountExpires.html
+++ b/src/main/resources/templates/mail/verifyEmailBeforeAccountExpires.html
@@ -13,9 +13,14 @@
             Your OncoKB account will expire in <span th:text="${expiresInDays}"></span> days. Please click the URL below to verify you still own this email address and to renew your account:
         </p>
         <p>
-            <a th:with="verifyUrl=${baseUrl} + '/account/verify',
-              url=(@{${verifyUrl}(key=${user.activationKey},login=${user.login})})" th:href="${url}"
+            <a th:with="url=(@{|${baseUrl}/account/verify?key=${user.activationKey}|})" th:href="${url}"
             th:text="${url}">Verification link</a>
+        </p>
+        <p>
+            If the link above does not work, you can verify your email manually by visiting <a th:with="url=(@{|${baseUrl}/account/verify|})" th:href="${url}" th:text="${url}">verification page</a> and entering the activation key below:
+        </p>
+        <p style="text-align: center;">
+            <strong th:text="${user.activationKey}">activation-key</strong>
         </p>
         <p>
             <div th:text="#{email.closing}">Sincerely,</div>

--- a/src/main/webapp/app/components/account/ActivateAccount.tsx
+++ b/src/main/webapp/app/components/account/ActivateAccount.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { RouterStore } from 'mobx-react-router';
 import * as QueryString from 'query-string';
 import client from 'app/shared/api/clientInstance';
-import { observable } from 'mobx';
+import { observable, action } from 'mobx';
 import LoadingIndicator from 'app/components/loadingIndicator/LoadingIndicator';
 import { remoteData } from 'cbioportal-frontend-commons';
 import { Link } from 'react-router-dom';
 import { ONCOKB_TM, PAGE_ROUTE } from 'app/config/constants';
 import { inject, observer } from 'mobx-react';
-import { Col, Row, Alert } from 'react-bootstrap';
+import { Alert, Form, Button } from 'react-bootstrap';
 import SmallPageContainer from '../SmallPageContainer';
 import MessageToContact from 'app/shared/texts/MessageToContact';
 import * as styles from '../../index.module.scss';
@@ -19,8 +19,7 @@ export default class ActivateAccount extends React.Component<{
   routing: RouterStore;
 }> {
   @observable activateKey: string;
-  @observable login: string;
-  @observable hasGracePeriod?: boolean;
+  @observable manualKey = '';
 
   constructor(props: Readonly<{ routing: RouterStore }>) {
     super(props);
@@ -29,31 +28,58 @@ export default class ActivateAccount extends React.Component<{
     if (queryStrings.key) {
       this.activateKey = queryStrings.key as string;
     }
-    if (queryStrings.login) {
-      this.login = queryStrings.login as string;
-    }
-    if (queryStrings.hasGracePeriod) {
-      const hasGracePeriod = (queryStrings.hasGracePeriod as string).toLowerCase();
-      if (hasGracePeriod === 'true') {
-        this.hasGracePeriod = true;
-      } else if (hasGracePeriod === 'false') {
-        this.hasGracePeriod = false;
-      }
-    }
   }
 
-  readonly activateAccount = remoteData<boolean>({
+  readonly activateAccount = remoteData({
     invoke: () => {
-      if (this.activateKey && this.login) {
+      if (this.activateKey) {
         return client.activateAccountUsingGET({
           key: this.activateKey,
-          login: this.login,
         });
       } else {
-        return Promise.reject('The key or login is empty');
+        return Promise.reject('The activation key is empty');
       }
     },
   });
+
+  @action.bound
+  submitManualKey() {
+    const trimmed = this.manualKey.trim();
+    if (trimmed) {
+      this.activateKey = trimmed;
+    }
+  }
+
+  getManualKeyForm = () => {
+    return (
+      <div>
+        <Alert variant={'info'} className={styles.biggerText}>
+          <p>
+            Please paste your activation key below to verify your email address.
+            You can find the key in the verification email you received.
+          </p>
+          <Form.Group className={'mb-3'}>
+            <Form.Label>Activation Key</Form.Label>
+            <Form.Control
+              type="text"
+              value={this.manualKey}
+              onChange={action((e: React.ChangeEvent<HTMLInputElement>) => {
+                this.manualKey = e.target.value;
+              })}
+              placeholder="Paste your activation key here"
+            />
+          </Form.Group>
+          <Button
+            variant="primary"
+            disabled={!this.manualKey.trim()}
+            onClick={this.submitManualKey}
+          >
+            Verify Email Address
+          </Button>
+        </Alert>
+      </div>
+    );
+  };
 
   getSuccessfulMessage = () => {
     return (
@@ -61,7 +87,7 @@ export default class ActivateAccount extends React.Component<{
         <Alert variant={'info'} className={styles.biggerText}>
           <p>
             Thank you for verifying your email address.{' '}
-            {this.activateAccount.result && (
+            {this.activateAccount.result?.activated && (
               <span>
                 You can now <Link to={PAGE_ROUTE.LOGIN}>login</Link> to your{' '}
                 {ONCOKB_TM} account.
@@ -69,20 +95,25 @@ export default class ActivateAccount extends React.Component<{
             )}
           </p>
 
-          {!this.activateAccount.result && (
+          {!this.activateAccount.result?.activated && (
             <p>
-              {this.hasGracePeriod === true ? (
-                <span>You have access while your request is under review.</span>
+              {this.activateAccount.result?.hasGracePeriod ? (
+                <>
+                  <span>
+                    You have access while your request is under review.
+                  </span>
+                  <span>
+                    {' '}
+                    You may now <Link to={PAGE_ROUTE.LOGIN}>log in</Link> to
+                    your {ONCOKB_TM} account.
+                  </span>
+                </>
               ) : (
                 <span>
                   You do not have a grace period. Access will be enabled after
                   approval.
                 </span>
-              )}{' '}
-              <span>
-                You may now <Link to={PAGE_ROUTE.LOGIN}>log in</Link> to your{' '}
-                {ONCOKB_TM} account.
-              </span>
+              )}
             </p>
           )}
           <MessageToContact
@@ -118,6 +149,10 @@ export default class ActivateAccount extends React.Component<{
   };
 
   render() {
+    if (!this.activateKey) {
+      return <SmallPageContainer>{this.getManualKeyForm()}</SmallPageContainer>;
+    }
+
     return (
       <SmallPageContainer>
         {this.activateAccount.isPending ? (

--- a/src/main/webapp/app/pages/RegisterPage.tsx
+++ b/src/main/webapp/app/pages/RegisterPage.tsx
@@ -226,17 +226,18 @@ export class RegisterPage extends React.Component<IRegisterProps> {
           the email to complete registration.
         </p>
         <p>
-          After validating your email address, you will be able to access the
-          OncoKB website. In parallel, your request will be reviewed on an
-          individual basis, and you may be contacted with follow-up questions.{' '}
           {noGracePeriod ? (
             <span>
-              You will not have a grace period since you are using a personal
-              email address.
+              While we review your request, you will not have a grace period to
+              browse the website since you are using a personal email address.
             </span>
           ) : (
             <span>
-              You will have access while your license request is under review.
+              After validating your email address, you will be able to access
+              the OncoKB website. In parallel, your request will be reviewed on
+              an individual basis, and you may be contacted with follow-up
+              questions. You will have access while your license request is
+              under review.
             </span>
           )}{' '}
           {licenseType === LicenseType.ACADEMIC ? (

--- a/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
+++ b/src/main/webapp/app/pages/companyPage/CompanyPage.tsx
@@ -381,13 +381,12 @@ export default class CompanyPage extends React.Component<ICompanyPage> {
   @action.bound
   async verifyUserEmail(user: UserDTO) {
     try {
-      const activated = await client.activateAccountUsingGET({
+      const result = await client.activateAccountUsingGET({
         key: user.activationKey,
-        login: user.login,
       });
       const updatedUser = {
         ...user,
-        activated,
+        activated: result.activated,
         activationKey: '',
         emailVerified: true,
       };

--- a/src/main/webapp/app/pages/userManagement/UserDetailsPage.tsx
+++ b/src/main/webapp/app/pages/userManagement/UserDetailsPage.tsx
@@ -168,13 +168,12 @@ export default class UserDetailsPage extends React.Component<{
   @action.bound
   async verifyUserEmail(user: UserDTO) {
     try {
-      const activated = await client.activateAccountUsingGET({
+      const result = await client.activateAccountUsingGET({
         key: user.activationKey,
-        login: user.login,
       });
       const updatedUser = {
         ...user,
-        activated,
+        activated: result.activated,
         activationKey: '',
         emailVerified: true,
       };

--- a/src/main/webapp/app/shared/api/generated/API.ts
+++ b/src/main/webapp/app/shared/api/generated/API.ts
@@ -1,6 +1,12 @@
 import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
+export type AccountActivationVM = {
+    'activated': boolean
+
+        'hasGracePeriod': boolean
+
+};
 export type Activation = {
     'activationDate': string
 
@@ -1676,17 +1682,12 @@ export default class API {
     };
     activateAccountUsingGETURL(parameters: {
         'key': string,
-        'login': string,
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
         let path = '/api/activate';
         if (parameters['key'] !== undefined) {
             queryParameters['key'] = parameters['key'];
-        }
-
-        if (parameters['login'] !== undefined) {
-            queryParameters['login'] = parameters['login'];
         }
 
         if (parameters.$queryParameters) {
@@ -1704,11 +1705,9 @@ export default class API {
      * @method
      * @name API#activateAccountUsingGET
      * @param {string} key - key
-     * @param {string} login - login
      */
     activateAccountUsingGETWithHttpInfo(parameters: {
         'key': string,
-        'login': string,
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < request.Response > {
@@ -1732,15 +1731,6 @@ export default class API {
                 return;
             }
 
-            if (parameters['login'] !== undefined) {
-                queryParameters['login'] = parameters['login'];
-            }
-
-            if (parameters['login'] === undefined) {
-                reject(new Error('Missing required  parameter: login'));
-                return;
-            }
-
             if (parameters.$queryParameters) {
                 Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
                     var parameter = parameters.$queryParameters[parameterName];
@@ -1758,14 +1748,12 @@ export default class API {
      * @method
      * @name API#activateAccountUsingGET
      * @param {string} key - key
-     * @param {string} login - login
      */
     activateAccountUsingGET(parameters: {
         'key': string,
-        'login': string,
         $queryParameters ? : any,
         $domain ? : string
-    }): Promise < boolean > {
+    }): Promise < AccountActivationVM > {
         return this.activateAccountUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
             return response.body;
         });

--- a/src/test/java/org/mskcc/cbio/oncokb/service/MailServiceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/MailServiceIT.java
@@ -304,8 +304,7 @@ public class MailServiceIT {
         assertThat(message.getAllRecipients()[0].toString()).isEqualTo(user.getEmail());
         assertThat(message.getFrom()[0].toString()).isEqualTo(jHipsterProperties.getMail().getFrom());
         assertThat(content).isNotEmpty();
-        assertThat(content).contains("hasGracePeriod=true");
-        // assertThat(content).contains("day grace period");
+        assertThat(content).contains("you will be able to access the OncoKB website");
         assertThat(message.getDataHandler().getContentType()).isEqualTo("text/html;charset=UTF-8");
     }
 
@@ -320,7 +319,6 @@ public class MailServiceIT {
         verify(javaMailSender).send(messageCaptor.capture());
         MimeMessage message = messageCaptor.getValue();
         String content = message.getContent().toString();
-        assertThat(content).contains("hasGracePeriod=false");
         assertThat(content).contains("Access will be enabled after approval is complete");
     }
 

--- a/src/test/java/org/mskcc/cbio/oncokb/web/rest/AccountResourceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/web/rest/AccountResourceIT.java
@@ -550,6 +550,7 @@ public class AccountResourceIT {
 
         UserDetails userDetails = new UserDetails();
         userDetails.setUser(user);
+        userDetails.setAccountRequestStatus(AccountRequestStatus.PENDING);
         userDetailsRepository.saveAndFlush(userDetails);
 
         restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))
@@ -588,6 +589,7 @@ public class AccountResourceIT {
 
         UserDetails userDetails = new UserDetails();
         userDetails.setUser(user);
+        userDetails.setAccountRequestStatus(AccountRequestStatus.PENDING);
         userDetailsRepository.saveAndFlush(userDetails);
 
         restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))
@@ -626,6 +628,7 @@ public class AccountResourceIT {
 
         UserDetails userDetails = new UserDetails();
         userDetails.setUser(user);
+        userDetails.setAccountRequestStatus(AccountRequestStatus.PENDING);
         userDetailsRepository.saveAndFlush(userDetails);
 
         restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))

--- a/src/test/java/org/mskcc/cbio/oncokb/web/rest/AccountResourceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/web/rest/AccountResourceIT.java
@@ -548,6 +548,10 @@ public class AccountResourceIT {
 
         userRepository.saveAndFlush(user);
 
+        UserDetails userDetails = new UserDetails();
+        userDetails.setUser(user);
+        userDetailsRepository.saveAndFlush(userDetails);
+
         restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))
             .andExpect(status().isOk());
 
@@ -582,6 +586,10 @@ public class AccountResourceIT {
         companyDTO.setCompanyDomains(Collections.singleton(companyDomain));
         companyRepository.saveAndFlush(companyMapper.toEntity(companyDTO));
 
+        UserDetails userDetails = new UserDetails();
+        userDetails.setUser(user);
+        userDetailsRepository.saveAndFlush(userDetails);
+
         restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))
             .andExpect(status().isOk());
 
@@ -615,6 +623,10 @@ public class AccountResourceIT {
         companyDTO.setCompanyType(CompanyType.PARENT);
         companyDTO.setCompanyDomains(Collections.singleton(companyDomain));
         companyRepository.saveAndFlush(companyMapper.toEntity(companyDTO));
+
+        UserDetails userDetails = new UserDetails();
+        userDetails.setUser(user);
+        userDetailsRepository.saveAndFlush(userDetails);
 
         restAccountMockMvc.perform(get("/api/activate?key={activationKey}&login={userLogin}", activationKey, userLogin))
             .andExpect(status().isOk());


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/1156
  
### Changes
- Content Transferm Encoding: Sets base64 encoding on outgoing emails to prevent link corruption in email clients that mangle special characters in URLs.
- Remove `login` and `hasGracePeriod` from activation URL. These can be figured out based off of activationKey alone
- Visiting `/account/verify` without a key param now shows a form where users can paste their activation key manually, as a fallback when email links don't work.
- Fix message when user signs up with personal email (was incorrectly saying they have access)