### PR TITLE
Hosptials are no longer auto approved on API access

### DIFF
--- a/scripts/register-random-user.sh
+++ b/scripts/register-random-user.sh
@@ -45,13 +45,15 @@ random_suffix() {
 SUFFIX="$(random_suffix)"
 EMAIL="test-user-${SUFFIX}@example.org"
 LOGIN="$EMAIL"
+FIRST_NAME="Test${SUFFIX}"
+LAST_NAME="User${SUFFIX}"
 
 PAYLOAD="$(cat <<EOF
 {
   "login": "$LOGIN",
   "password": "$PASSWORD",
-  "firstName": "Test",
-  "lastName": "User",
+  "firstName": "$FIRST_NAME",
+  "lastName": "$LAST_NAME",
   "email": "$EMAIL",
   "licenseType": "$LICENSE_TYPE",
   "companyName": "Test Org",

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/SlackController.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/SlackController.java
@@ -65,7 +65,12 @@ public class SlackController {
             userDTO.getId()
         );
 
-        if (!userDTO.getLicenseType().equals(LicenseType.ACADEMIC) || apiAccessRequested) {
+        boolean shouldGrantApiAccess = LicenseType.COMMERCIAL.equals(userDTO.getLicenseType())
+            || LicenseType.RESEARCH_IN_COMMERCIAL.equals(userDTO.getLicenseType())
+            || (LicenseType.ACADEMIC.equals(userDTO.getLicenseType()) && apiAccessRequested)
+            || (LicenseType.HOSPITAL.equals(userDTO.getLicenseType()) && apiAccessRequested);
+
+        if (shouldGrantApiAccess) {
             log.info("Giving the user API access");
             Set<String> userDTOAuthorities = userDTO.getAuthorities();
             userDTOAuthorities.add(AuthoritiesConstants.API);

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserResource.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/UserResource.java
@@ -129,9 +129,6 @@ public class UserResource {
             if (managedUserVM.getAuthorities() == null || managedUserVM.getAuthorities().isEmpty()) {
                 Set<String> authorities = new LinkedHashSet<>();
                 authorities.add(AuthoritiesConstants.USER);
-                if (!managedUserVM.getLicenseType().equals(LicenseType.ACADEMIC)) {
-                    authorities.add(AuthoritiesConstants.API);
-                }
                 managedUserVM.setAuthorities(Collections.unmodifiableSet(authorities));
             }
             User newUser = userService.createUser(managedUserVM, false, Optional.ofNullable(managedUserVM.getTokenValidDays()), Optional.ofNullable(managedUserVM.getTokenIsRenewable()));

--- a/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
+++ b/src/main/webapp/app/components/newAccountForm/NewAccountForm.tsx
@@ -23,6 +23,7 @@ import {
 import {
   ACADEMIC_TERMS,
   ACCOUNT_TITLES,
+  AUTHORITIES,
   LicenseStatus,
   LicenseType,
   ONCOKB_TM,
@@ -101,6 +102,7 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
   @observable companyOptions: CompanySelectOptionType[] = [];
   @observable selectedCompanyOption: CompanySelectOptionType | undefined;
   @observable apiAccessRequested = false;
+  @observable adminApiAccessEnabled = true;
 
   private defaultFormValue = {
     accountType: ACCOUNT_TYPE_DEFAULT,
@@ -139,6 +141,11 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
       city: values.city,
       country: values.country,
     };
+    if (this.props.byAdmin) {
+      newUser.authorities = this.adminApiAccessEnabled
+        ? [AUTHORITIES.USER, AUTHORITIES.API]
+        : [AUTHORITIES.USER];
+    }
     const additionalInfo = this.constructAdditionalInfo(values);
     if (Object.keys(additionalInfo).length > 0) {
       newUser.additionalInfo = additionalInfo;
@@ -854,6 +861,30 @@ export class NewAccountForm extends React.Component<INewAccountForm> {
                   </Col>
                 </Row>
               </>
+            ) : null}
+            {this.props.byAdmin ? (
+              <Row className={getSectionClassName()}>
+                <Col md="3">
+                  <h5>API Access</h5>
+                </Col>
+                <Col md="9">
+                  <AvCheckboxGroup
+                    name="adminApiAccess"
+                    key="adminApiAccess"
+                    errorMessage={'You have to accept the term'}
+                  >
+                    <AvCheckbox
+                      label={'Grant API Access'}
+                      value={this.adminApiAccessEnabled}
+                      checked={this.adminApiAccessEnabled}
+                      onChange={() =>
+                        (this.adminApiAccessEnabled = !this
+                          .adminApiAccessEnabled)
+                      }
+                    />
+                  </AvCheckboxGroup>
+                </Col>
+              </Row>
             ) : null}
             {this.props.byAdmin ? (
               <Row className={getSectionClassName()}>

--- a/src/main/webapp/app/pages/CreateCompanyUsersPage.tsx
+++ b/src/main/webapp/app/pages/CreateCompanyUsersPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 import { RouteComponentProps } from 'react-router';
-import { Row, Col, Button, Alert, Tab, Tabs, Form } from 'react-bootstrap';
+import { Row, Col, Button, Alert, Tab, Tabs } from 'react-bootstrap';
 import { getSectionClassName } from './account/AccountUtils';
 import { action, observable } from 'mobx';
 import { CompanyDTO, ManagedUserVM } from 'app/shared/api/generated/API';
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 import { getErrorMessage } from 'app/shared/alert/ErrorAlertUtils';
 import { COLOR_LIGHT_GREY } from 'app/config/theme';
 import { partition } from 'app/shared/utils/LodashUtils';
+import { AUTHORITIES } from 'app/config/constants';
 
 interface MatchParams {
   id: string;
@@ -127,6 +128,7 @@ export class CreateCompanyUsersPage extends React.Component<
           this.company.result?.licenseStatus !== LicenseStatus.TRIAL,
         company: this.company.result,
         companyName: this.company.result?.name,
+        authorities: [AUTHORITIES.USER, AUTHORITIES.API],
         notifyUserOnTrialCreation:
           this.company.result?.licenseStatus === LicenseStatus.TRIAL,
       } as ManagedUserVM;

--- a/src/test/java/org/mskcc/cbio/oncokb/web/rest/SlackControllerIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/web/rest/SlackControllerIT.java
@@ -37,9 +37,12 @@ import org.mskcc.cbio.oncokb.repository.UserDetailsRepository;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
 import org.mskcc.cbio.oncokb.service.*;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
+import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
+import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.ApiAccessRequest;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.TrialAccount;
 import org.mskcc.cbio.oncokb.service.impl.TokenServiceImpl;
 import org.mskcc.cbio.oncokb.service.mapper.UserMapper;
+import org.mskcc.cbio.oncokb.security.AuthoritiesConstants;
 import org.mskcc.cbio.oncokb.web.rest.slack.ActionId;
 import org.mskcc.cbio.oncokb.web.rest.slack.BlockId;
 import org.mskcc.cbio.oncokb.web.rest.slack.DropdownEmailOption;
@@ -250,6 +253,7 @@ public class SlackControllerIT {
         UserDetails mockUserDetails = userDetailsRepository.findOneByUser(mockUser).orElse(null);
         assertThat(mockUserDetails).isNotNull();
         assertThat(mockUserDetails.getAccountRequestStatus()).isEqualTo(AccountRequestStatus.APPROVED);
+        assertThat(mockUser.getAuthorities()).extracting("name").contains(AuthoritiesConstants.API);
 
         // Check user token
         List<Token> mockTokens = tokenService.findByUser(mockUser);
@@ -270,6 +274,45 @@ public class SlackControllerIT {
         String expandUrl = urlCaptor.getValue();
         Payload expandPayload = payloadCaptor.getValue();
         checkSlackBlock(expandUrl, expandPayload, ActionId.APPROVE_USER, false);
+    }
+
+    @Test
+    void testApproveHospitalUserWithoutApiRequestDoesNotGrantApiAccess() throws IOException, MessagingException {
+        User mockUser = userRepository.findOneWithAuthoritiesByLogin(DEFAULT_USER_EMAIL).orElseThrow();
+        UserDetails mockUserDetails = userDetailsRepository.findOneByUser(mockUser).orElseThrow();
+        mockUserDetails.setLicenseType(LicenseType.HOSPITAL);
+        userDetailsRepository.saveAndFlush(mockUserDetails);
+
+        BlockActionPayload actionJSON = getBlockActionPayload(ActionId.APPROVE_USER);
+        Gson snakeCase = GsonFactory.createSnakeCase();
+        slackController.approveUser(snakeCase.toJson(actionJSON));
+
+        User updatedUser = userRepository.findOneWithAuthoritiesByLogin(DEFAULT_USER_EMAIL).orElseThrow();
+        assertThat(updatedUser.getActivated()).isTrue();
+        assertThat(updatedUser.getAuthorities()).extracting("name").doesNotContain(AuthoritiesConstants.API);
+    }
+
+    @Test
+    void testApproveHospitalUserWithApiRequestGrantsApiAccess() throws IOException, MessagingException {
+        User mockUser = userRepository.findOneWithAuthoritiesByLogin(DEFAULT_USER_EMAIL).orElseThrow();
+        UserDetails mockUserDetails = userDetailsRepository.findOneByUser(mockUser).orElseThrow();
+        mockUserDetails.setLicenseType(LicenseType.HOSPITAL);
+
+        AdditionalInfoDTO additionalInfoDTO = new AdditionalInfoDTO();
+        ApiAccessRequest apiAccessRequest = new ApiAccessRequest();
+        apiAccessRequest.setRequested(true);
+        apiAccessRequest.setJustification("Hospital reporting");
+        additionalInfoDTO.setApiAccessRequest(apiAccessRequest);
+        mockUserDetails.setAdditionalInfo(new Gson().toJson(additionalInfoDTO));
+        userDetailsRepository.saveAndFlush(mockUserDetails);
+
+        BlockActionPayload actionJSON = getBlockActionPayload(ActionId.APPROVE_USER);
+        Gson snakeCase = GsonFactory.createSnakeCase();
+        slackController.approveUser(snakeCase.toJson(actionJSON));
+
+        User updatedUser = userRepository.findOneWithAuthoritiesByLogin(DEFAULT_USER_EMAIL).orElseThrow();
+        assertThat(updatedUser.getActivated()).isTrue();
+        assertThat(updatedUser.getAuthorities()).extracting("name").contains(AuthoritiesConstants.API);
     }
 
     @Test

--- a/src/test/java/org/mskcc/cbio/oncokb/web/rest/UserResourceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/web/rest/UserResourceIT.java
@@ -167,6 +167,83 @@ public class UserResourceIT {
 
     @Test
     @Transactional
+    public void createHospitalUserWithoutAuthoritiesDoesNotDefaultApiRole() throws Exception {
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin("hospital-user");
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail("hospital-user@localhost");
+        managedUserVM.setActivated(true);
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setLicenseType(LicenseType.HOSPITAL);
+
+        restUserMockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(managedUserVM)))
+            .andExpect(status().isCreated());
+
+        User createdUser = userRepository.findOneWithAuthoritiesByLogin("hospital-user").orElseThrow();
+        assertThat(createdUser.getAuthorities()).extracting("name")
+            .contains(AuthoritiesConstants.USER)
+            .doesNotContain(AuthoritiesConstants.API);
+    }
+
+    @Test
+    @Transactional
+    public void createCommercialUserWithoutAuthoritiesDoesNotDefaultApiRole() throws Exception {
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin("commercial-user");
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail("commercial-user@localhost");
+        managedUserVM.setActivated(true);
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setLicenseType(LicenseType.COMMERCIAL);
+
+        restUserMockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(managedUserVM)))
+            .andExpect(status().isCreated());
+
+        User createdUser = userRepository.findOneWithAuthoritiesByLogin("commercial-user").orElseThrow();
+        assertThat(createdUser.getAuthorities()).extracting("name")
+            .contains(AuthoritiesConstants.USER)
+            .doesNotContain(AuthoritiesConstants.API);
+    }
+
+    @Test
+    @Transactional
+    public void createUserWithExplicitApiRolePersistsApiRole() throws Exception {
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin("explicit-api-user");
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail("explicit-api-user@localhost");
+        managedUserVM.setActivated(true);
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setLicenseType(LicenseType.HOSPITAL);
+        managedUserVM.setAuthorities(
+            new LinkedHashSet<>(Arrays.asList(AuthoritiesConstants.USER, AuthoritiesConstants.API))
+        );
+
+        restUserMockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(TestUtil.convertObjectToJsonBytes(managedUserVM)))
+            .andExpect(status().isCreated());
+
+        User createdUser = userRepository.findOneWithAuthoritiesByLogin("explicit-api-user").orElseThrow();
+        assertThat(createdUser.getAuthorities()).extracting("name")
+            .contains(AuthoritiesConstants.USER, AuthoritiesConstants.API);
+    }
+
+    @Test
+    @Transactional
     public void createUserWithExistingId() throws Exception {
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 


### PR DESCRIPTION
closes https://github.com/oncokb/oncokb-pipeline/issues/1173

This PR fixes the hospital API-access regression by removing backend assumptions that hospital users should automatically receive ROLE_API just because they are non-academic. Hospital users now only get API access when it is explicitly requested in the approval flow. The change is applied across the main implicit-grant paths: Slack approval logic, company license propagation, and admin-created user defaults.

It also moves POST /api/users authority selection to the frontend for admin-created users. The standalone admin create-user page now shows a checked-by-default “Grant API Access” checkbox, and submits either ROLE_USER or ROLE_USER ROLE_API based on that choice. The company-user creation flow remains unchanged in behavior and always includes API access explicitly, since company-level backend logic still grants it.
