### PR TITLE
Update/code gen

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "buildNewsPages": "node scripts/generate-markdown.js -f src/main/webapp/app/pages/newsPage/markdown -o src/main/webapp/app/pages/newsPage/code-generated && yarn run prettier --write \"{,src/main/webapp/app/pages/newsPage/code-generated/**/}*.{md,json,ts,tsx,css,scss,yml}\"",
     "buildPrivacyNotice": "node scripts/generate-markdown.js -f src/main/webapp/app/pages/privacyNotice/markdown -o src/main/webapp/app/pages/privacyNotice/code-generated && yarn run prettier --write \"{,src/main/webapp/app/pages/privacyNotice/code-generated/**/}*.{md,json,ts,tsx,css,scss,yml}\"",
     "updateOncoKbAPI": "yarn run fetchOncoKbAPI && yarn run buildOncoKbAPI",
-    "fetchOncoKbAPI": "curl http://localhost:8080/oncokb-public/api/v1/v2/api-docs?group=Private%20APIs | json | grep -v basePath | grep -v termsOfService | grep -v host > src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json && curl http://localhost:8080/oncokb-public/api/private/v2/api-docs | json | grep -v basePath | grep -v termsOfService | grep -v host > src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json",
+    "fetchOncoKbAPI": "curl http://localhost:8080/app/api/v1/v2/api-docs?group=Private%20APIs | json | grep -v basePath | grep -v termsOfService | grep -v host > src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json && curl http://localhost:8080/app/api/private/v2/api-docs | json | grep -v basePath | grep -v termsOfService | grep -v host > src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json",
     "buildOncoKbAPI": "node scripts/generate-api.js src/main/webapp/app/shared/api/generated OncoKbAPI OncoKbPrivateAPI",
     "test": "yarn run jest --",
     "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config jest.conf.js",

--- a/scripts/generate-api.js
+++ b/scripts/generate-api.js
@@ -1,13 +1,38 @@
 const fs = require('fs');
 const path = require('path');
-const request = require('request');
 const CodeGen = require('swagger-js-codegen').CodeGen;
 
-const [node, script, folder, ...classNames] = process.argv;
-for (const className of classNames)
-{
-  const swagger = JSON.parse(fs.readFileSync(path.join(folder, `${className}-docs.json`)));
-  const tsSourceCode = CodeGen.getTypescriptCode({className, swagger});
+function addNullToNullableEnums(value) {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
 
-  fs.writeFileSync(path.join(folder, `${className}.ts`), tsSourceCode);
+  const nullable =
+    typeof value.description === 'string' &&
+    value.description.trim().startsWith('(Nullable)');
+
+  if (nullable && Array.isArray(value.enum) && !value.enum.includes(null)) {
+    value.enum.push(null);
+  }
+
+  Object.values(value).forEach(addNullToNullableEnums);
 }
+
+function generateApi(folder, classNames) {
+  for (const className of classNames) {
+    const swagger = JSON.parse(
+      fs.readFileSync(path.join(folder, `${className}-docs.json`))
+    );
+    addNullToNullableEnums(swagger);
+
+    const tsSourceCode = CodeGen.getTypescriptCode({ className, swagger });
+    fs.writeFileSync(path.join(folder, `${className}.ts`), tsSourceCode);
+  }
+}
+
+if (require.main === module) {
+  const [, , folder, ...classNames] = process.argv;
+  generateApi(folder, classNames);
+}
+
+module.exports = { addNullToNullableEnums, generateApi };

--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -591,7 +591,6 @@ export const DEFAULT_GERMLINE_ANNOTATION: GermlineVariantAnnotation = {
   geneSummary: '',
   genomicIndicators: [],
   highestDiagnosticImplicationLevel: 'NO',
-  highestFdaLevel: 'NO',
   highestPrognosticImplicationLevel: 'NO',
   highestResistanceLevel: 'NO',
   highestSensitiveLevel: 'NO',

--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -4,6 +4,8 @@ import {
   GeneNumber,
   GermlineVariantAnnotation,
   MainNumber,
+  MutationEffectResp,
+  Query,
   SomaticVariantAnnotation,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import React from 'react';
@@ -474,7 +476,7 @@ export const DEFAULT_GENE_NUMBER: GeneNumber = {
   tumorType: 0,
 };
 
-export const DEFAULT_MUTATION_EFFECT = {
+export const DEFAULT_MUTATION_EFFECT: MutationEffectResp = {
   citations: {
     abstracts: [],
     pmids: [],
@@ -497,9 +499,9 @@ export const DEFAULT_GERMLINE_VARIANT = {
   penetranceDescription: '',
 };
 
-export const DEFAULT_QUERY = {
+export const DEFAULT_QUERY: Query = {
   alteration: '',
-  alterationType: '',
+  alterationType: 'MUTATION',
   consequence: '',
   entrezGeneId: -1,
   hgvs: '',
@@ -508,12 +510,9 @@ export const DEFAULT_QUERY = {
   id: '',
   proteinEnd: -1,
   proteinStart: -1,
-  referenceGenome: 'GRCH37' as any,
-  svType: 'UNKNOWN' as 'UNKNOWN',
+  referenceGenome: 'GRCh37',
+  svType: 'UNKNOWN',
   tumorType: '',
-  type: '',
-  germline: false,
-  alleleState: '',
   canonicalTranscript: '',
 };
 
@@ -553,15 +552,15 @@ export const DEFAULT_ANNOTATION: SomaticVariantAnnotation = {
   diagnosticSummary: '',
   geneExist: false,
   geneSummary: '',
-  highestDiagnosticImplicationLevel: 'NO',
-  highestPrognosticImplicationLevel: 'NO',
-  highestResistanceLevel: 'NO',
-  highestSensitiveLevel: 'NO',
-  highestFdaLevel: 'NO',
+  highestDiagnosticImplicationLevel: 'NO' as any,
+  highestPrognosticImplicationLevel: 'NO' as any,
+  highestResistanceLevel: 'NO' as any,
+  highestSensitiveLevel: 'NO' as any,
+  highestFdaLevel: 'NO' as any,
   hotspot: false,
   lastUpdate: '',
   mutationEffect: DEFAULT_MUTATION_EFFECT,
-  oncogenic: '',
+  oncogenic: '' as any,
   exon: '',
   otherSignificantResistanceLevels: [],
   otherSignificantSensitiveLevels: [],
@@ -581,23 +580,18 @@ export const DEFAULT_ANNOTATION: SomaticVariantAnnotation = {
 };
 
 export const DEFAULT_GERMLINE_ANNOTATION: GermlineVariantAnnotation = {
-  alleleExist: false,
-  clinVarId: '',
   dataVersion: '',
   diagnosticImplications: [],
   diagnosticSummary: '',
-  exon: '',
   geneExist: false,
   geneSummary: '',
   genomicIndicators: [],
-  highestDiagnosticImplicationLevel: 'NO',
-  highestPrognosticImplicationLevel: 'NO',
-  highestResistanceLevel: 'NO',
-  highestSensitiveLevel: 'NO',
+  highestDiagnosticImplicationLevel: 'NO' as any,
+  highestPrognosticImplicationLevel: 'NO' as any,
+  highestResistanceLevel: 'NO' as any,
+  highestSensitiveLevel: 'NO' as any,
   lastUpdate: '',
   mutationEffect: DEFAULT_MUTATION_EFFECT,
-  otherSignificantResistanceLevels: [],
-  otherSignificantSensitiveLevels: [],
   pathogenic: '',
   penetrance: '',
   prognosticImplications: [],

--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -560,7 +560,7 @@ export const DEFAULT_ANNOTATION: SomaticVariantAnnotation = {
   hotspot: false,
   lastUpdate: '',
   mutationEffect: DEFAULT_MUTATION_EFFECT,
-  oncogenic: '' as any,
+  oncogenic: 'Unknown',
   exon: '',
   otherSignificantResistanceLevels: [],
   otherSignificantSensitiveLevels: [],

--- a/src/main/webapp/app/pages/actionableGenesPage/ActionableGenesPage.tsx
+++ b/src/main/webapp/app/pages/actionableGenesPage/ActionableGenesPage.tsx
@@ -16,6 +16,7 @@ import {
   Evidence,
   TumorType,
   Treatment as EvidenceTreatment,
+  TumorTypeEntity,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import Select from 'react-select';
 import {
@@ -81,9 +82,9 @@ type Treatment = {
   hugoSymbol: string;
   alterations: Alteration[];
   alterationsName: string;
-  cancerTypes: TumorType[];
-  excludedCancerTypes: TumorType[];
-  relevantCancerTypes: TumorType[];
+  cancerTypes: TumorTypeEntity[];
+  excludedCancerTypes: TumorTypeEntity[];
+  relevantCancerTypes: TumorTypeEntity[];
   cancerTypesName: string;
   treatment: EvidenceTreatment | undefined;
   uniqueDrugs: string[];

--- a/src/main/webapp/app/pages/annotationPage/SomaticTagCancerTypePage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/SomaticTagCancerTypePage.tsx
@@ -13,7 +13,6 @@ import {
   EnsemblGene,
   SomaticVariantAnnotation,
   Tag,
-  VariantAnnotation,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import client from 'app/shared/api/oncokbClientInstance';
 import privateClient from 'app/shared/api/oncokbPrivateClientInstance';

--- a/src/main/webapp/app/pages/annotationPage/SomaticTagCancerTypePage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/SomaticTagCancerTypePage.tsx
@@ -30,6 +30,13 @@ import {
   getImplicationsFromTags,
   getTagVariantOverview,
 } from 'app/shared/utils/Utils';
+import {
+  getHighestDiagnosticImplicationLevel,
+  getHighestFdaLevel,
+  getHighestPrognosticImplicationLevel,
+  getHighestResistanceLevel,
+  getHighestSensitiveLevel,
+} from 'app/shared/utils/LevelUtils';
 import AppStore from 'app/store/AppStore';
 import AuthenticationStore from 'app/store/AuthenticationStore';
 import WindowStore from 'app/store/WindowStore';
@@ -194,13 +201,21 @@ const SomaticTagCancerTypePage = inject(
 
           const highestLevelInfo: SomaticVariantAnnotation = {
             ...DEFAULT_ANNOTATION,
-            highestSensitiveLevel: tag.highestLevels.highestSensitiveLevel,
-            highestDiagnosticImplicationLevel:
-              tag.highestLevels.highestDiagnosticLevel,
-            highestPrognosticImplicationLevel:
-              tag.highestLevels.highestPrognosticLevel,
-            highestResistanceLevel: tag.highestLevels.highestResistanceLevel,
-            highestFdaLevel: tag.highestLevels.highestFDALevel,
+            highestSensitiveLevel: getHighestSensitiveLevel(
+              tag.highestLevels.highestSensitiveLevel
+            ),
+            highestDiagnosticImplicationLevel: getHighestDiagnosticImplicationLevel(
+              tag.highestLevels.highestDiagnosticLevel
+            ),
+            highestPrognosticImplicationLevel: getHighestPrognosticImplicationLevel(
+              tag.highestLevels.highestPrognosticLevel
+            ),
+            highestResistanceLevel: getHighestResistanceLevel(
+              tag.highestLevels.highestResistanceLevel
+            ),
+            highestFdaLevel: getHighestFdaLevel(
+              tag.highestLevels.highestFDALevel
+            ),
           };
 
           return (

--- a/src/main/webapp/app/pages/companionDiagnosticDevicesPage/companionDiagnosticDevicePage.tsx
+++ b/src/main/webapp/app/pages/companionDiagnosticDevicesPage/companionDiagnosticDevicePage.tsx
@@ -28,7 +28,10 @@ import {
   tumorTypeSortMethod,
 } from 'app/shared/utils/ReactTableUtils';
 import privateClient from 'app/shared/api/oncokbPrivateClientInstance';
-import { TumorType } from 'app/shared/api/generated/OncoKbPrivateAPI';
+import {
+  TumorType,
+  TumorTypeEntity,
+} from 'app/shared/api/generated/OncoKbPrivateAPI';
 import { FdaSubmissionLink } from 'app/shared/links/FdaSubmissionLink';
 import { Linkout } from 'app/shared/links/Linkout';
 import InfoIcon from 'app/shared/icons/InfoIcon';
@@ -275,7 +278,7 @@ const CompanionDiagnosticDevicePage: React.FunctionComponent<{}> = () => {
 
     const getFilteredCdx = async () => {
       if (filterPresent) {
-        let rcts: TumorType[] = [];
+        let rcts: TumorTypeEntity[] = [];
         for (const ct of selectedCancerTypes) {
           rcts = rcts.concat(
             await privateClient.utilRelevantTumorTypesGetUsingGET({

--- a/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticTagPage.tsx
+++ b/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticTagPage.tsx
@@ -12,7 +12,6 @@ import {
   EnsemblGene,
   SomaticVariantAnnotation,
   Tag,
-  VariantAnnotation,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import client from 'app/shared/api/oncokbClientInstance';
 import privateClient from 'app/shared/api/oncokbPrivateClientInstance';

--- a/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticTagPage.tsx
+++ b/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticTagPage.tsx
@@ -28,6 +28,13 @@ import {
   getImplicationsFromTags,
   getTagVariantOverview,
 } from 'app/shared/utils/Utils';
+import {
+  getHighestDiagnosticImplicationLevel,
+  getHighestFdaLevel,
+  getHighestPrognosticImplicationLevel,
+  getHighestResistanceLevel,
+  getHighestSensitiveLevel,
+} from 'app/shared/utils/LevelUtils';
 import AppStore from 'app/store/AppStore';
 import { inject } from 'mobx-react';
 import { RouterStore } from 'mobx-react-router';
@@ -182,13 +189,21 @@ const SomaticTagPage = inject(
           const { tag, gene, ensemblGenes, geneSummary } = pageLoadState.data;
           const highestLevelInfo: SomaticVariantAnnotation = {
             ...DEFAULT_ANNOTATION,
-            highestSensitiveLevel: tag.highestLevels.highestSensitiveLevel,
-            highestDiagnosticImplicationLevel:
-              tag.highestLevels.highestDiagnosticLevel,
-            highestPrognosticImplicationLevel:
-              tag.highestLevels.highestPrognosticLevel,
-            highestResistanceLevel: tag.highestLevels.highestResistanceLevel,
-            highestFdaLevel: tag.highestLevels.highestFDALevel,
+            highestSensitiveLevel: getHighestSensitiveLevel(
+              tag.highestLevels.highestSensitiveLevel
+            ),
+            highestDiagnosticImplicationLevel: getHighestDiagnosticImplicationLevel(
+              tag.highestLevels.highestDiagnosticLevel
+            ),
+            highestPrognosticImplicationLevel: getHighestPrognosticImplicationLevel(
+              tag.highestLevels.highestPrognosticLevel
+            ),
+            highestResistanceLevel: getHighestResistanceLevel(
+              tag.highestLevels.highestResistanceLevel
+            ),
+            highestFdaLevel: getHighestFdaLevel(
+              tag.highestLevels.highestFDALevel
+            ),
           };
 
           return (

--- a/src/main/webapp/app/shared/api/GenerateApi.spec.ts
+++ b/src/main/webapp/app/shared/api/GenerateApi.spec.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const CodeGen = require('swagger-js-codegen').CodeGen;
+const {
+  addNullToNullableEnums,
+} = require('../../../../../../scripts/generate-api');
+
+describe('generate-api', () => {
+  it('generates null unions for enums described as nullable', () => {
+    const swagger = {
+      swagger: '2.0',
+      info: {},
+      paths: {},
+      definitions: {
+        LevelInfo: {
+          type: 'object',
+          properties: {
+            highestDiagnosticLevel: {
+              type: 'string',
+              description: '(Nullable) The highest diagnostic level.',
+              enum: ['LEVEL_Dx1', 'NO'],
+            },
+          },
+        },
+      },
+    };
+
+    addNullToNullableEnums(swagger);
+
+    const output = CodeGen.getTypescriptCode({
+      className: 'TestAPI',
+      swagger,
+    });
+    expect(output).toContain(
+      `'highestDiagnosticLevel': "LEVEL_Dx1" | "NO" | null`
+    );
+  });
+});

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json
@@ -2796,48 +2796,112 @@
       "properties": {
         "highestDiagnosticLevel": {
           "type": "string",
-          "description": "(Nullable) The highest diagnostic level from this tag's diagnostic evidences.",
-          "enum": [
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3"
-          ]
-        },
-        "highestFDALevel": {
-          "type": "string",
-          "description": "(Nullable) The highest FDA level from this tag's therapeutic evidences.",
-          "enum": [
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3"
-          ]
-        },
-        "highestPrognosticLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest prognostic level from this tag's prognostic evidences.",
-          "enum": [
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3"
-          ]
-        },
-        "highestResistanceLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest resistance level from this tag's therapeutic evidences.",
-          "enum": [
-            "LEVEL_R1",
-            "LEVEL_R2"
-          ]
-        },
-        "highestSensitiveLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest sensitivity level from this tag's therapeutic evidences.",
           "enum": [
             "LEVEL_1",
             "LEVEL_2",
             "LEVEL_3A",
             "LEVEL_3B",
-            "LEVEL_4"
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestFDALevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestPrognosticLevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestResistanceLevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestSensitiveLevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
           ]
         }
       }

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "These endpoints are for private use only.",
-    "version": "v1.5.0",
+    "version": "v1.6.0",
     "title": "OncoKB Private APIs",
     "contact": {
       "name": "OncoKB",
@@ -28,8 +28,8 @@
       "description": "Clinical Trials Matching"
     },
     {
-      "name": "Annotations",
-      "description": "Providing annotation services"
+      "name": "Annotations for Somatic",
+      "description": "Somatic endpoints"
     },
     {
       "name": "Cancer Genes",
@@ -38,6 +38,10 @@
     {
       "name": "Genes",
       "description": "OncoKB Genes"
+    },
+    {
+      "name": "Annotations for Germline",
+      "description": "Germline endpoints"
     },
     {
       "name": "Genesets",
@@ -56,10 +60,6 @@
       "description": "The search endpoints"
     },
     {
-      "name": "Germline Annotations",
-      "description": "Providing germline annotations"
-    },
-    {
       "name": "Evidences",
       "description": "OncoKB Evidence"
     }
@@ -68,7 +68,7 @@
     "/annotate/copyNumberAlterations": {
       "get": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateCopyNumberAlterationsGet",
         "description": "Annotate copy number alteration.",
@@ -148,7 +148,7 @@
       },
       "post": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateCopyNumberAlterationsPost",
         "description": "Annotate copy number alterations.",
@@ -192,10 +192,307 @@
         }
       }
     },
+    "/annotate/germline/mutations/byGenomicChange": {
+      "get": {
+        "tags": [
+          "Annotations for Germline"
+        ],
+        "summary": "annotateMutationsByGenomicChangeGet",
+        "description": "Annotate mutation by genomic change.",
+        "operationId": "annotateMutationsByGenomicChangeGetUsingGET_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "genomicLocation",
+            "in": "query",
+            "description": "Genomic location following TCGA MAF format. Example: 7,140453136,140453136,A,T",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "referenceGenome",
+            "in": "query",
+            "description": "Reference genome, either GRCh37 or GRCh38. The default is GRCh37",
+            "required": false,
+            "type": "string",
+            "default": "GRCh37"
+          },
+          {
+            "name": "tumorType",
+            "in": "query",
+            "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GermlineIndicatorQueryResp"
+            }
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Annotations for Germline"
+        ],
+        "summary": "annotateMutationsByGenomicChangePost",
+        "description": "Annotate mutations by genomic change.",
+        "operationId": "annotateMutationsByGenomicChangePostUsingPOST_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of queries. Please see swagger.json for request body format.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AnnotateMutationByGenomicChangeQuery"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GermlineIndicatorQueryResp"
+              }
+            }
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          }
+        }
+      }
+    },
+    "/annotate/germline/mutations/byHGVSc": {
+      "get": {
+        "tags": [
+          "Annotations for Germline"
+        ],
+        "summary": "annotateMutationsByHGVScGet",
+        "description": "Annotate mutation by HGVSc.",
+        "operationId": "annotateMutationsByHGVScGetUsingGET_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "hgvsc",
+            "in": "query",
+            "description": "HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "referenceGenome",
+            "in": "query",
+            "description": "Reference genome, either GRCh37 or GRCh38. The default is GRCh37",
+            "required": false,
+            "type": "string",
+            "default": "GRCh37"
+          },
+          {
+            "name": "tumorType",
+            "in": "query",
+            "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GermlineIndicatorQueryResp"
+            }
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Annotations for Germline"
+        ],
+        "summary": "annotateMutationsByHGVScPost",
+        "description": "Annotate mutations by HGVSc.",
+        "operationId": "annotateMutationsByHGVScPostUsingPOST_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of queries. Please see swagger.json for request body format.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AnnotateMutationByHGVScQuery"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GermlineIndicatorQueryResp"
+              }
+            }
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          }
+        }
+      }
+    },
+    "/annotate/germline/mutations/byHGVSg": {
+      "get": {
+        "tags": [
+          "Annotations for Germline"
+        ],
+        "summary": "annotateMutationsByHGVSgGet",
+        "description": "Annotate mutation by HGVSg.",
+        "operationId": "annotateMutationsByHGVSgGetUsingGET_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "hgvsg",
+            "in": "query",
+            "description": "HGVS genomic format following HGVS nomenclature. Example: 7:g.140453136A>T",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "referenceGenome",
+            "in": "query",
+            "description": "Reference genome, either GRCh37 or GRCh38. The default is GRCh37",
+            "required": false,
+            "type": "string",
+            "default": "GRCh37"
+          },
+          {
+            "name": "tumorType",
+            "in": "query",
+            "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GermlineIndicatorQueryResp"
+            }
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Annotations for Germline"
+        ],
+        "summary": "annotateMutationsByHGVSgPost",
+        "description": "Annotate mutations by HGVSg.",
+        "operationId": "annotateMutationsByHGVSgPostUsingPOST_1",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of queries. Please see swagger.json for request body format.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AnnotateMutationByHGVSgQuery"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GermlineIndicatorQueryResp"
+              }
+            }
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          }
+        }
+      }
+    },
     "/annotate/mutations/byGenomicChange": {
       "get": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateMutationsByGenomicChangeGet",
         "description": "Annotate mutation by genomic change.",
@@ -254,7 +551,7 @@
       },
       "post": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateMutationsByGenomicChangePost",
         "description": "Annotate mutations by genomic change.",
@@ -301,7 +598,7 @@
     "/annotate/mutations/byHGVSg": {
       "get": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateMutationsByHGVSgGet",
         "description": "Annotate mutation by HGVSg.",
@@ -360,7 +657,7 @@
       },
       "post": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateMutationsByHGVSgPost",
         "description": "Annotate mutations by HGVSg.",
@@ -407,7 +704,7 @@
     "/annotate/mutations/byProteinChange": {
       "get": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateMutationsByProteinChangeGet",
         "description": "Annotate mutation by protein change.",
@@ -516,7 +813,7 @@
       },
       "post": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateMutationsByProteinChangePost",
         "description": "Annotate mutations by protein change.",
@@ -563,7 +860,7 @@
     "/annotate/sample": {
       "post": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateSamplePost",
         "description": "Annotate samples.",
@@ -610,7 +907,7 @@
     "/annotate/structuralVariants": {
       "get": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateStructuralVariantsGet",
         "description": "Annotate structural variant.",
@@ -716,7 +1013,7 @@
       },
       "post": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotateStructuralVariantsPost",
         "description": "Annotate structural variants.",
@@ -763,7 +1060,7 @@
     "/annotation/search": {
       "get": {
         "tags": [
-          "Annotations"
+          "Annotations for Somatic"
         ],
         "summary": "annotationSearchGet",
         "description": "Get annotations based on search",
@@ -798,305 +1095,8 @@
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/AnnotationSearchResult"
+                "$ref": "#/definitions/SomaticAnnotationSearchResult"
               }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/annotate/germline/mutations/byGenomicChange": {
-      "get": {
-        "tags": [
-          "Germline Annotations"
-        ],
-        "summary": "annotateMutationsByGenomicChangeGet",
-        "description": "Annotate mutation by genomic change.",
-        "operationId": "annotateMutationsByGenomicChangeGetUsingGET_1",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "genomicLocation",
-            "in": "query",
-            "description": "Genomic location following TCGA MAF format. Example: 7,140453136,140453136,A,T",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "referenceGenome",
-            "in": "query",
-            "description": "Reference genome, either GRCh37 or GRCh38. The default is GRCh37",
-            "required": false,
-            "type": "string",
-            "default": "GRCh37"
-          },
-          {
-            "name": "tumorType",
-            "in": "query",
-            "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/GermlineIndicatorQueryResp"
-            }
-          },
-          "400": {
-            "description": "Error, error message will be given.",
-            "schema": {
-              "$ref": "#/definitions/ApiHttpError"
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Germline Annotations"
-        ],
-        "summary": "annotateMutationsByGenomicChangePost",
-        "description": "Annotate mutations by genomic change.",
-        "operationId": "annotateMutationsByGenomicChangePostUsingPOST_1",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "description": "List of queries. Please see swagger.json for request body format.",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AnnotateMutationByGenomicChangeQuery"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GermlineIndicatorQueryResp"
-              }
-            }
-          },
-          "400": {
-            "description": "Error, error message will be given.",
-            "schema": {
-              "$ref": "#/definitions/ApiHttpError"
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/annotate/germline/mutations/byHGVSc": {
-      "get": {
-        "tags": [
-          "Germline Annotations"
-        ],
-        "summary": "annotateMutationsByHGVScGet",
-        "description": "Annotate mutation by HGVSc.",
-        "operationId": "annotateMutationsByHGVScGetUsingGET_1",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "hgvsc",
-            "in": "query",
-            "description": "HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "referenceGenome",
-            "in": "query",
-            "description": "Reference genome, either GRCh37 or GRCh38. The default is GRCh37",
-            "required": false,
-            "type": "string",
-            "default": "GRCh37"
-          },
-          {
-            "name": "tumorType",
-            "in": "query",
-            "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/GermlineIndicatorQueryResp"
-            }
-          },
-          "400": {
-            "description": "Error, error message will be given.",
-            "schema": {
-              "$ref": "#/definitions/ApiHttpError"
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Germline Annotations"
-        ],
-        "summary": "annotateMutationsByHGVScPost",
-        "description": "Annotate mutations by HGVSc.",
-        "operationId": "annotateMutationsByHGVScPostUsingPOST_1",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "description": "List of queries. Please see swagger.json for request body format.",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AnnotateMutationByHGVScQuery"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GermlineIndicatorQueryResp"
-              }
-            }
-          },
-          "400": {
-            "description": "Error, error message will be given.",
-            "schema": {
-              "$ref": "#/definitions/ApiHttpError"
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/annotate/germline/mutations/byHGVSg": {
-      "get": {
-        "tags": [
-          "Germline Annotations"
-        ],
-        "summary": "annotateMutationsByHGVSgGet",
-        "description": "Annotate mutation by HGVSg.",
-        "operationId": "annotateMutationsByHGVSgGetUsingGET_1",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "hgvsg",
-            "in": "query",
-            "description": "HGVS genomic format following HGVS nomenclature. Example: 7:g.140453136A>T",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "referenceGenome",
-            "in": "query",
-            "description": "Reference genome, either GRCh37 or GRCh38. The default is GRCh37",
-            "required": false,
-            "type": "string",
-            "default": "GRCh37"
-          },
-          {
-            "name": "tumorType",
-            "in": "query",
-            "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/GermlineIndicatorQueryResp"
-            }
-          },
-          "400": {
-            "description": "Error, error message will be given.",
-            "schema": {
-              "$ref": "#/definitions/ApiHttpError"
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Germline Annotations"
-        ],
-        "summary": "annotateMutationsByHGVSgPost",
-        "description": "Annotate mutations by HGVSg.",
-        "operationId": "annotateMutationsByHGVSgPostUsingPOST_1",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "description": "List of queries. Please see swagger.json for request body format.",
-            "required": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AnnotateMutationByHGVSgQuery"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GermlineIndicatorQueryResp"
-              }
-            }
-          },
-          "400": {
-            "description": "Error, error message will be given.",
-            "schema": {
-              "$ref": "#/definitions/ApiHttpError"
             }
           }
         }
@@ -2629,6 +2629,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -2639,6 +2640,9 @@
         },
         "genomicLocation": {
           "type": "string"
+        },
+        "germline": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -2784,6 +2788,57 @@
         },
         "title": {
           "type": "string"
+        }
+      }
+    },
+    "LevelInfo": {
+      "type": "object",
+      "properties": {
+        "highestDiagnosticLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest diagnostic level from this tag's diagnostic evidences.",
+          "enum": [
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3"
+          ]
+        },
+        "highestFDALevel": {
+          "type": "string",
+          "description": "(Nullable) The highest FDA level from this tag's therapeutic evidences.",
+          "enum": [
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3"
+          ]
+        },
+        "highestPrognosticLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest prognostic level from this tag's prognostic evidences.",
+          "enum": [
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3"
+          ]
+        },
+        "highestResistanceLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest resistance level from this tag's therapeutic evidences.",
+          "enum": [
+            "LEVEL_R1",
+            "LEVEL_R2"
+          ]
+        },
+        "highestSensitiveLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest sensitivity level from this tag's therapeutic evidences.",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4"
+          ]
         }
       }
     },
@@ -3076,6 +3131,7 @@
             "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
             "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
             "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+            "TX_ADDENDUM",
             "PATHOGENIC",
             "GENOMIC_INDICATOR",
             "GENE_PENETRANCE",
@@ -3125,6 +3181,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -3141,6 +3198,9 @@
         },
         "geneB": {
           "$ref": "#/definitions/QueryGene"
+        },
+        "germline": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -3218,6 +3278,9 @@
         "referenceGenome": {
           "type": "string"
         },
+        "setting": {
+          "type": "string"
+        },
         "solidPropagationLevel": {
           "type": "string"
         },
@@ -3289,6 +3352,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -3300,8 +3364,8 @@
         "gene": {
           "type": "string"
         },
-        "germlineQuery": {
-          "$ref": "#/definitions/GermlineQuery"
+        "germline": {
+          "type": "boolean"
         },
         "hgvsc": {
           "type": "string"
@@ -3393,14 +3457,6 @@
         }
       }
     },
-    "GermlineQuery": {
-      "type": "object",
-      "properties": {
-        "germline": {
-          "type": "boolean"
-        }
-      }
-    },
     "VariantConsequence": {
       "type": "object",
       "properties": {
@@ -3412,6 +3468,48 @@
         },
         "term": {
           "type": "string"
+        }
+      }
+    },
+    "EvidenceQueries": {
+      "type": "object",
+      "properties": {
+        "evidenceTypes": {
+          "type": "string"
+        },
+        "highestLevelOnly": {
+          "type": "boolean"
+        },
+        "levels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "LEVEL_1",
+              "LEVEL_2",
+              "LEVEL_3A",
+              "LEVEL_3B",
+              "LEVEL_4",
+              "LEVEL_R1",
+              "LEVEL_R2",
+              "LEVEL_Px1",
+              "LEVEL_Px2",
+              "LEVEL_Px3",
+              "LEVEL_Dx1",
+              "LEVEL_Dx2",
+              "LEVEL_Dx3",
+              "LEVEL_Fda1",
+              "LEVEL_Fda2",
+              "LEVEL_Fda3",
+              "NO"
+            ]
+          }
+        },
+        "queries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Query"
+          }
         }
       }
     },
@@ -3448,6 +3546,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -3458,6 +3557,9 @@
         },
         "gene": {
           "$ref": "#/definitions/QueryGene"
+        },
+        "germline": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -3478,10 +3580,12 @@
       "type": "object",
       "properties": {
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the genomic indicator"
         },
         "inheritanceMechanism": {
           "type": "string",
+          "description": "Describes how a genetic trait/allele may be passed to offspring",
           "enum": [
             "AUTOSOMAL_DOMINANT",
             "AUTOSOMAL_RECESSIVE",
@@ -3490,9 +3594,11 @@
           ]
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the clinical syndrome"
         }
-      }
+      },
+      "description": "clinical syndromes associated with specific germline variants/alleles that describe the clinical consequences associated with that variant"
     },
     "TumorTypeEntity": {
       "type": "object",
@@ -3670,123 +3776,11 @@
         "referenceGenome": {
           "type": "string"
         },
+        "setting": {
+          "type": "string"
+        },
         "variant": {
           "type": "string"
-        }
-      }
-    },
-    "LevelInfo": {
-      "type": "object",
-      "properties": {
-        "highestDiagnosticLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestFDALevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestPrognosticLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestResistanceLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestSensitiveLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
         }
       }
     },
@@ -3816,7 +3810,7 @@
         },
         "exon": {
           "type": "string",
-          "description": "(Nullable) The affected exon of this variant, if applicable (currently only supported when annotating via HGVSg or Genomic Location)"
+          "description": "DEPRECATED. (Nullable) The affected exon of this variant, if applicable (currently only supported when annotating via HGVSg or Genomic Location)"
         },
         "geneExist": {
           "type": "boolean",
@@ -3831,92 +3825,35 @@
           "type": "string",
           "description": "(Nullable) The highest diagnostic level from a list of diagnostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
             "LEVEL_Dx1",
             "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Dx3"
           ]
         },
         "highestFdaLevel": {
           "type": "string",
           "description": "(Nullable) The highest FDA level from a list of therapeutic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
             "LEVEL_Fda1",
             "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Fda3"
           ]
         },
         "highestPrognosticImplicationLevel": {
           "type": "string",
           "description": "(Nullable) The highest prognostic level from a list of prognostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
             "LEVEL_Px1",
             "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Px3"
           ]
         },
         "highestResistanceLevel": {
           "type": "string",
           "description": "(Nullable) The highest resistance level from a list of therapeutic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
             "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_R2"
           ]
         },
         "highestSensitiveLevel": {
@@ -3927,19 +3864,7 @@
             "LEVEL_2",
             "LEVEL_3A",
             "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_4"
           ]
         },
         "hotspot": {
@@ -3957,7 +3882,15 @@
         },
         "oncogenic": {
           "type": "string",
-          "description": "The oncogenicity status of the variant. Defaulted to \"Unknown\"."
+          "description": "The oncogenicity status of the variant. Defaulted to \"Unknown\".",
+          "enum": [
+            "Oncogenic",
+            "Likely Oncogenic",
+            "Likely Neutral",
+            "Inconclusive",
+            "Resistance",
+            "Unknown"
+          ]
         },
         "otherSignificantResistanceLevels": {
           "type": "array",
@@ -4079,14 +4012,6 @@
     "GermlineIndicatorQueryResp": {
       "type": "object",
       "properties": {
-        "alleleExist": {
-          "type": "boolean",
-          "example": false,
-          "description": "Indicates whether the alternate allele has been curated. See SOP Protocol 9.1"
-        },
-        "clinVarId": {
-          "type": "string"
-        },
         "dataVersion": {
           "type": "string",
           "example": "v4.25",
@@ -4102,10 +4027,6 @@
         "diagnosticSummary": {
           "type": "string",
           "description": "Diagnostic summary. Defaulted to \"\""
-        },
-        "exon": {
-          "type": "string",
-          "description": "(Nullable) The affected exon of this variant, if applicable (currently only supported when annotating via HGVSg or Genomic Location)"
         },
         "geneExist": {
           "type": "boolean",
@@ -4126,92 +4047,26 @@
           "type": "string",
           "description": "(Nullable) The highest diagnostic level from a list of diagnostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
             "LEVEL_Dx1",
             "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestFdaLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest FDA level from a list of therapeutic evidences.",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Dx3"
           ]
         },
         "highestPrognosticImplicationLevel": {
           "type": "string",
           "description": "(Nullable) The highest prognostic level from a list of prognostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
             "LEVEL_Px1",
             "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Px3"
           ]
         },
         "highestResistanceLevel": {
           "type": "string",
           "description": "(Nullable) The highest resistance level from a list of therapeutic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
             "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_R2"
           ]
         },
         "highestSensitiveLevel": {
@@ -4222,19 +4077,7 @@
             "LEVEL_2",
             "LEVEL_3A",
             "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_4"
           ]
         },
         "lastUpdate": {
@@ -4245,63 +4088,13 @@
         "mutationEffect": {
           "$ref": "#/definitions/MutationEffectResp"
         },
-        "otherSignificantResistanceLevels": {
-          "type": "array",
-          "description": "DEPRECATED",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
-        "otherSignificantSensitiveLevels": {
-          "type": "array",
-          "description": "DEPRECATED",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
         "pathogenic": {
-          "type": "string"
+          "type": "string",
+          "description": "(Nullable) The classification of the likelihood that a germline variant will cause disease."
         },
         "penetrance": {
-          "type": "string"
+          "type": "string",
+          "description": "(Nullable) The likelihood that individuals with a specific variant will become affected"
         },
         "prognosticImplications": {
           "type": "array",
@@ -4339,23 +4132,6 @@
         },
         "vus": {
           "type": "boolean"
-        }
-      }
-    },
-    "AnnotationSearchResult": {
-      "type": "object",
-      "properties": {
-        "queryType": {
-          "type": "string",
-          "enum": [
-            "GENE",
-            "VARIANT",
-            "DRUG",
-            "CANCER_TYPE"
-          ]
-        },
-        "somaticIndicatorQueryResp": {
-          "$ref": "#/definitions/SomaticIndicatorQueryResp"
         }
       }
     },
@@ -4405,6 +4181,7 @@
             "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
             "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
             "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+            "TX_ADDENDUM",
             "PATHOGENIC",
             "GENOMIC_INDICATOR",
             "GENE_PENETRANCE",
@@ -4629,6 +4406,9 @@
           "type": "string"
         },
         "hugoSymbol": {
+          "type": "string"
+        },
+        "setting": {
           "type": "string"
         },
         "summary": {
@@ -4873,6 +4653,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -4883,6 +4664,9 @@
         },
         "gene": {
           "$ref": "#/definitions/QueryGene"
+        },
+        "germline": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -5092,6 +4876,20 @@
         }
       }
     },
+    "MutationTypeEntity": {
+      "type": "object",
+      "properties": {
+        "mutationType": {
+          "type": "string",
+          "enum": [
+            "MISSENSE",
+            "INSERTION",
+            "DELETION",
+            "OTHER"
+          ]
+        }
+      }
+    },
     "Treatment": {
       "type": "object",
       "properties": {
@@ -5113,101 +4911,6 @@
         }
       }
     },
-    "EvidenceQueries": {
-      "type": "object",
-      "properties": {
-        "evidenceTypes": {
-          "type": "string"
-        },
-        "highestLevelOnly": {
-          "type": "boolean"
-        },
-        "levels": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
-        "queries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Query"
-          }
-        }
-      }
-    },
-    "VariantSearchQuery": {
-      "type": "object",
-      "properties": {
-        "consequence": {
-          "type": "string"
-        },
-        "entrezGeneId": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "hgvs": {
-          "type": "string"
-        },
-        "hugoSymbol": {
-          "type": "string"
-        },
-        "proteinEnd": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "proteinStart": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "referenceGenome": {
-          "type": "string",
-          "enum": [
-            "GRCh37",
-            "GRCh38"
-          ]
-        },
-        "variant": {
-          "type": "string"
-        },
-        "variantType": {
-          "type": "string"
-        }
-      }
-    },
-    "MutationTypeEntity": {
-      "type": "object",
-      "properties": {
-        "mutationType": {
-          "type": "string",
-          "enum": [
-            "MISSENSE",
-            "INSERTION",
-            "DELETION",
-            "OTHER"
-          ]
-        }
-      }
-    },
     "MutationEffectResp": {
       "type": "object",
       "properties": {
@@ -5221,7 +4924,19 @@
         },
         "knownEffect": {
           "type": "string",
-          "description": "Indicates the effect of the mutation on the gene. Defaulted to \"\""
+          "description": "Indicates the effect of the mutation on the gene. Defaulted to \"\"",
+          "enum": [
+            "Gain-of-function",
+            "Inconclusive",
+            "Loss-of-function",
+            "Likely Loss-of-function",
+            "Likely Gain-of-function",
+            "Neutral",
+            "Unknown",
+            "Likely Switch-of-function",
+            "Switch-of-function",
+            "Likely Neutral"
+          ]
         }
       }
     },
@@ -5249,6 +4964,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -5256,6 +4972,9 @@
               "VARIANT_CANCER_RISK"
             ]
           }
+        },
+        "germline": {
+          "type": "boolean"
         },
         "hgvsg": {
           "type": "string"
@@ -5275,7 +4994,24 @@
         }
       }
     },
-     "Tag": {
+    "SomaticAnnotationSearchResult": {
+      "type": "object",
+      "properties": {
+        "queryType": {
+          "type": "string",
+          "enum": [
+            "GENE",
+            "VARIANT",
+            "DRUG",
+            "CANCER_TYPE"
+          ]
+        },
+        "somaticIndicatorQueryResp": {
+          "$ref": "#/definitions/SomaticIndicatorQueryResp"
+        }
+      }
+    },
+    "Tag": {
       "type": "object",
       "properties": {
         "description": {

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
@@ -2,9 +2,11 @@ import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type AnnotateMutationByGenomicChangeQuery = {
-    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
 
         'genomicLocation': string
+
+        'germline': boolean
 
         'id': string
 
@@ -26,7 +28,7 @@ export type OncogenicityEntity = {
 export type Query = {
     'alteration': string
 
-        'alterationType': string
+        'alterationType': "MUTATION" | "COPY_NUMBER_ALTERATION" | "STRUCTURAL_VARIANT"
 
         'canonicalTranscript': string
 
@@ -65,12 +67,38 @@ export type ApiHttpError = {
         'title': string
 
 };
+export type LevelInfo = {
+    'highestDiagnosticLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+
+        'highestFDALevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
+
+        'highestPrognosticLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+
+};
 export type ParsedVersionInfo = {
     'genomeNexusVepVersion': string
 
         'genomeNexusVersion': string
 
         'vepVersion': string
+
+};
+export type SemVer = {
+    'major': number
+
+        'minor': number
+
+        'patch': number
+
+        'stable': boolean
+
+        'suffixTokens': Array < string >
+
+        'version': string
 
 };
 export type Implication = {
@@ -97,7 +125,28 @@ export type MutationsQuery = {
         'proteinChange': Array < AnnotateMutationByProteinChangeQuery >
 
 };
+export type TumorType = {
+    'children': {}
 
+    'code': string
+
+        'color': string
+
+        'id': number
+
+        'level': number
+
+        'mainType': MainType
+
+        'name': string
+
+        'parent': string
+
+        'tissue': string
+
+        'tumorForm': "SOLID" | "LIQUID" | "MIXED"
+
+};
 export type Gene = {
     'entrezGeneId': number
 
@@ -135,7 +184,7 @@ export type GeneEvidence = {
 
         'evidenceId': number
 
-        'evidenceType': "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK"
+        'evidenceType': "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK"
 
         'gene': Gene
 
@@ -149,13 +198,15 @@ export type GeneEvidence = {
 
 };
 export type AnnotateStructuralVariantQuery = {
-    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
 
         'functionalFusion': boolean
 
         'geneA': QueryGene
 
         'geneB': QueryGene
+
+        'germline': boolean
 
         'id': string
 
@@ -197,6 +248,8 @@ export type ActionableGene = {
 
         'referenceGenome': string
 
+        'setting': string
+
         'solidPropagationLevel': string
 
         'variant': string
@@ -215,11 +268,11 @@ export type InfoLevel = {
 export type AnnotateMutationByHGVScQuery = {
     'alteration': string
 
-        'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+        'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
 
         'gene': string
 
-        'germlineQuery': GermlineQuery
+        'germline': boolean
 
         'hgvsc': string
 
@@ -268,10 +321,6 @@ export type OncoKBInfo = {
         'publicInstance': boolean
 
 };
-export type GermlineQuery = {
-    'germline': boolean
-
-};
 export type VariantConsequence = {
     'description': string
 
@@ -293,9 +342,11 @@ export type EvidenceQueries = {
 export type AnnotateCopyNumberAlterationQuery = {
     'copyNameAlterationType': "AMPLIFICATION" | "DELETION" | "GAIN" | "LOSS"
 
-        'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+        'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
 
         'gene': QueryGene
+
+        'germline': boolean
 
         'id': string
 
@@ -312,7 +363,7 @@ export type GenomicIndicator = {
         'name': string
 
 };
-export type TumorType = {
+export type TumorTypeEntity = {
     'code': string
 
         'color': string
@@ -411,36 +462,11 @@ export type AnnotatedVariant = {
 
         'referenceGenome': string
 
+        'setting': string
+
         'variant': string
 
 };
-export type LevelInfo = {
-    'highestDiagnosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestFDALevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestPrognosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-};
-export type SemVer = {
-    'major': number
-
-        'minor': number
-
-        'patch': number
-
-        'stable': boolean
-
-        'suffixTokens': Array < string >
-
-        'version': string
-
-};
-
 export type SomaticIndicatorQueryResp = {
     'alleleExist': boolean
 
@@ -456,15 +482,15 @@ export type SomaticIndicatorQueryResp = {
 
         'geneSummary': string
 
-        'highestDiagnosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
 
-        'highestFdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestFdaLevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
 
-        'highestPrognosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
 
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
 
         'hotspot': boolean
 
@@ -472,7 +498,7 @@ export type SomaticIndicatorQueryResp = {
 
         'mutationEffect': MutationEffectResp
 
-        'oncogenic': string
+        'oncogenic': "Oncogenic" | "Likely Oncogenic" | "Likely Neutral" | "Inconclusive" | "Resistance" | "Unknown"
 
         'otherSignificantResistanceLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
 
@@ -508,17 +534,11 @@ export type AnnotateSampleQuery = {
 
 };
 export type GermlineIndicatorQueryResp = {
-    'alleleExist': boolean
-
-        'clinVarId': string
-
-        'dataVersion': string
+    'dataVersion': string
 
         'diagnosticImplications': Array < Implication >
 
         'diagnosticSummary': string
-
-        'exon': string
 
         'geneExist': boolean
 
@@ -526,23 +546,17 @@ export type GermlineIndicatorQueryResp = {
 
         'genomicIndicators': Array < GenomicIndicator >
 
-        'highestDiagnosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
 
-        'highestFdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
 
-        'highestPrognosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
 
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
 
         'lastUpdate': string
 
         'mutationEffect': MutationEffectResp
-
-        'otherSignificantResistanceLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
-
-        'otherSignificantSensitiveLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
 
         'pathogenic': string
 
@@ -565,12 +579,6 @@ export type GermlineIndicatorQueryResp = {
         'vus': boolean
 
 };
-export type AnnotationSearchResult = {
-    'queryType': "GENE" | "VARIANT" | "DRUG" | "CANCER_TYPE"
-
-        'somaticIndicatorQueryResp': SomaticIndicatorQueryResp
-
-};
 export type Evidence = {
     'additionalInfo': string
 
@@ -578,13 +586,13 @@ export type Evidence = {
 
         'articles': Array < Article >
 
-        'cancerTypes': Array < TumorType >
+        'cancerTypes': Array < TumorTypeEntity >
 
         'description': string
 
-        'evidenceType': "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK"
+        'evidenceType': "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK"
 
-        'excludedCancerTypes': Array < TumorType >
+        'excludedCancerTypes': Array < TumorTypeEntity >
 
         'fdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
@@ -604,11 +612,11 @@ export type Evidence = {
 
         'name': string
 
-        'relevantCancerTypes': Array < TumorType >
+        'relevantCancerTypes': Array < TumorTypeEntity >
 
         'solidPropagationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'tags': Array<Tag>
+        'tags': Array < Tag >
 
         'treatments': Array < Treatment >
 
@@ -658,6 +666,8 @@ export type CuratedGene = {
 
         'hugoSymbol': string
 
+        'setting': string
+
         'summary': string
 
 };
@@ -670,7 +680,7 @@ export type EvidenceQueryRes = {
 
         'exactMatchedAlteration': Alteration
 
-        'exactMatchedTumorType': TumorType
+        'exactMatchedTumorType': TumorTypeEntity
 
         'gene': Gene
 
@@ -678,7 +688,7 @@ export type EvidenceQueryRes = {
 
         'levelOfEvidences': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
 
-        'oncoTreeTypes': Array < TumorType >
+        'oncoTreeTypes': Array < TumorTypeEntity >
 
         'query': Query
 
@@ -752,9 +762,11 @@ export type AnnotateMutationByProteinChangeQuery = {
 
         'consequence': string
 
-        'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+        'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
 
         'gene': QueryGene
+
+        'germline': boolean
 
         'id': string
 
@@ -797,6 +809,10 @@ export type ResponseEntity = {
         'statusCodeValue': number
 
 };
+export type MutationTypeEntity = {
+    'mutationType': "MISSENSE" | "INSERTION" | "DELETION" | "OTHER"
+
+};
 export type Treatment = {
     'approvedIndications': Array < string >
 
@@ -805,40 +821,18 @@ export type Treatment = {
         'priority': number
 
 };
-export type VariantSearchQuery = {
-    'consequence': string
-
-        'entrezGeneId': number
-
-        'hgvs': string
-
-        'hugoSymbol': string
-
-        'proteinEnd': number
-
-        'proteinStart': number
-
-        'referenceGenome': "GRCh37" | "GRCh38"
-
-        'variant': string
-
-        'variantType': string
-
-};
-export type MutationTypeEntity = {
-    'mutationType': "MISSENSE" | "INSERTION" | "DELETION" | "OTHER"
-
-};
 export type MutationEffectResp = {
     'citations': Citations
 
         'description': string
 
-        'knownEffect': string
+        'knownEffect': "Gain-of-function" | "Inconclusive" | "Loss-of-function" | "Likely Loss-of-function" | "Likely Gain-of-function" | "Neutral" | "Unknown" | "Likely Switch-of-function" | "Switch-of-function" | "Likely Neutral"
 
 };
 export type AnnotateMutationByHGVSgQuery = {
-    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+
+        'germline': boolean
 
         'hgvsg': string
 
@@ -847,6 +841,12 @@ export type AnnotateMutationByHGVSgQuery = {
         'referenceGenome': "GRCh37" | "GRCh38"
 
         'tumorType': string
+
+};
+export type SomaticAnnotationSearchResult = {
+    'queryType': "GENE" | "VARIANT" | "DRUG" | "CANCER_TYPE"
+
+        'somaticIndicatorQueryResp': SomaticIndicatorQueryResp
 
 };
 export type Tag = {
@@ -1156,6 +1156,552 @@ export default class OncoKbAPI {
         }): Promise < Array < SomaticIndicatorQueryResp >
         > {
             return this.annotateCopyNumberAlterationsPostUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    annotateMutationsByGenomicChangeGetUsingGET_1URL(parameters: {
+        'genomicLocation': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/annotate/germline/mutations/byGenomicChange';
+        if (parameters['genomicLocation'] !== undefined) {
+            queryParameters['genomicLocation'] = parameters['genomicLocation'];
+        }
+
+        if (parameters['referenceGenome'] !== undefined) {
+            queryParameters['referenceGenome'] = parameters['referenceGenome'];
+        }
+
+        if (parameters['tumorType'] !== undefined) {
+            queryParameters['tumorType'] = parameters['tumorType'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Annotate mutation by genomic change.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByGenomicChangeGetUsingGET_1
+     * @param {string} genomicLocation - Genomic location following TCGA MAF format. Example: 7,140453136,140453136,A,T
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
+     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     */
+    annotateMutationsByGenomicChangeGetUsingGET_1WithHttpInfo(parameters: {
+        'genomicLocation': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byGenomicChange';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['genomicLocation'] !== undefined) {
+                queryParameters['genomicLocation'] = parameters['genomicLocation'];
+            }
+
+            if (parameters['genomicLocation'] === undefined) {
+                reject(new Error('Missing required  parameter: genomicLocation'));
+                return;
+            }
+
+            if (parameters['referenceGenome'] !== undefined) {
+                queryParameters['referenceGenome'] = parameters['referenceGenome'];
+            }
+
+            if (parameters['tumorType'] !== undefined) {
+                queryParameters['tumorType'] = parameters['tumorType'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Annotate mutation by genomic change.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByGenomicChangeGetUsingGET_1
+     * @param {string} genomicLocation - Genomic location following TCGA MAF format. Example: 7,140453136,140453136,A,T
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
+     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     */
+    annotateMutationsByGenomicChangeGetUsingGET_1(parameters: {
+        'genomicLocation': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < GermlineIndicatorQueryResp > {
+        return this.annotateMutationsByGenomicChangeGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+    annotateMutationsByGenomicChangePostUsingPOST_1URL(parameters: {
+        'body': Array < AnnotateMutationByGenomicChangeQuery > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/annotate/germline/mutations/byGenomicChange';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Annotate mutations by genomic change.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByGenomicChangePostUsingPOST_1
+     * @param {} body - List of queries. Please see swagger.json for request body format.
+     */
+    annotateMutationsByGenomicChangePostUsingPOST_1WithHttpInfo(parameters: {
+        'body': Array < AnnotateMutationByGenomicChangeQuery > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byGenomicChange';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['body'] !== undefined) {
+                body = parameters['body'];
+            }
+
+            if (parameters['body'] === undefined) {
+                reject(new Error('Missing required  parameter: body'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Annotate mutations by genomic change.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByGenomicChangePostUsingPOST_1
+     * @param {} body - List of queries. Please see swagger.json for request body format.
+     */
+    annotateMutationsByGenomicChangePostUsingPOST_1(parameters: {
+            'body': Array < AnnotateMutationByGenomicChangeQuery > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GermlineIndicatorQueryResp >
+        > {
+            return this.annotateMutationsByGenomicChangePostUsingPOST_1WithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    annotateMutationsByHGVScGetUsingGET_1URL(parameters: {
+        'hgvsc': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/annotate/germline/mutations/byHGVSc';
+        if (parameters['hgvsc'] !== undefined) {
+            queryParameters['hgvsc'] = parameters['hgvsc'];
+        }
+
+        if (parameters['referenceGenome'] !== undefined) {
+            queryParameters['referenceGenome'] = parameters['referenceGenome'];
+        }
+
+        if (parameters['tumorType'] !== undefined) {
+            queryParameters['tumorType'] = parameters['tumorType'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Annotate mutation by HGVSc.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVScGetUsingGET_1
+     * @param {string} hgvsc - HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
+     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     */
+    annotateMutationsByHGVScGetUsingGET_1WithHttpInfo(parameters: {
+        'hgvsc': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byHGVSc';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['hgvsc'] !== undefined) {
+                queryParameters['hgvsc'] = parameters['hgvsc'];
+            }
+
+            if (parameters['hgvsc'] === undefined) {
+                reject(new Error('Missing required  parameter: hgvsc'));
+                return;
+            }
+
+            if (parameters['referenceGenome'] !== undefined) {
+                queryParameters['referenceGenome'] = parameters['referenceGenome'];
+            }
+
+            if (parameters['tumorType'] !== undefined) {
+                queryParameters['tumorType'] = parameters['tumorType'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Annotate mutation by HGVSc.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVScGetUsingGET_1
+     * @param {string} hgvsc - HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
+     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     */
+    annotateMutationsByHGVScGetUsingGET_1(parameters: {
+        'hgvsc': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < GermlineIndicatorQueryResp > {
+        return this.annotateMutationsByHGVScGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+    annotateMutationsByHGVScPostUsingPOST_1URL(parameters: {
+        'body': Array < AnnotateMutationByHGVScQuery > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/annotate/germline/mutations/byHGVSc';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Annotate mutations by HGVSc.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVScPostUsingPOST_1
+     * @param {} body - List of queries. Please see swagger.json for request body format.
+     */
+    annotateMutationsByHGVScPostUsingPOST_1WithHttpInfo(parameters: {
+        'body': Array < AnnotateMutationByHGVScQuery > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byHGVSc';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['body'] !== undefined) {
+                body = parameters['body'];
+            }
+
+            if (parameters['body'] === undefined) {
+                reject(new Error('Missing required  parameter: body'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Annotate mutations by HGVSc.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVScPostUsingPOST_1
+     * @param {} body - List of queries. Please see swagger.json for request body format.
+     */
+    annotateMutationsByHGVScPostUsingPOST_1(parameters: {
+            'body': Array < AnnotateMutationByHGVScQuery > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GermlineIndicatorQueryResp >
+        > {
+            return this.annotateMutationsByHGVScPostUsingPOST_1WithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    annotateMutationsByHGVSgGetUsingGET_1URL(parameters: {
+        'hgvsg': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/annotate/germline/mutations/byHGVSg';
+        if (parameters['hgvsg'] !== undefined) {
+            queryParameters['hgvsg'] = parameters['hgvsg'];
+        }
+
+        if (parameters['referenceGenome'] !== undefined) {
+            queryParameters['referenceGenome'] = parameters['referenceGenome'];
+        }
+
+        if (parameters['tumorType'] !== undefined) {
+            queryParameters['tumorType'] = parameters['tumorType'];
+        }
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Annotate mutation by HGVSg.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVSgGetUsingGET_1
+     * @param {string} hgvsg - HGVS genomic format following HGVS nomenclature. Example: 7:g.140453136A>T
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
+     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     */
+    annotateMutationsByHGVSgGetUsingGET_1WithHttpInfo(parameters: {
+        'hgvsg': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byHGVSg';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['hgvsg'] !== undefined) {
+                queryParameters['hgvsg'] = parameters['hgvsg'];
+            }
+
+            if (parameters['hgvsg'] === undefined) {
+                reject(new Error('Missing required  parameter: hgvsg'));
+                return;
+            }
+
+            if (parameters['referenceGenome'] !== undefined) {
+                queryParameters['referenceGenome'] = parameters['referenceGenome'];
+            }
+
+            if (parameters['tumorType'] !== undefined) {
+                queryParameters['tumorType'] = parameters['tumorType'];
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Annotate mutation by HGVSg.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVSgGetUsingGET_1
+     * @param {string} hgvsg - HGVS genomic format following HGVS nomenclature. Example: 7:g.140453136A>T
+     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
+     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     */
+    annotateMutationsByHGVSgGetUsingGET_1(parameters: {
+        'hgvsg': string,
+        'referenceGenome' ? : string,
+        'tumorType' ? : string,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < GermlineIndicatorQueryResp > {
+        return this.annotateMutationsByHGVSgGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
+            return response.body;
+        });
+    };
+    annotateMutationsByHGVSgPostUsingPOST_1URL(parameters: {
+        'body': Array < AnnotateMutationByHGVSgQuery > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/annotate/germline/mutations/byHGVSg';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Annotate mutations by HGVSg.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVSgPostUsingPOST_1
+     * @param {} body - List of queries. Please see swagger.json for request body format.
+     */
+    annotateMutationsByHGVSgPostUsingPOST_1WithHttpInfo(parameters: {
+        'body': Array < AnnotateMutationByHGVSgQuery > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/annotate/germline/mutations/byHGVSg';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['body'] !== undefined) {
+                body = parameters['body'];
+            }
+
+            if (parameters['body'] === undefined) {
+                reject(new Error('Missing required  parameter: body'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Annotate mutations by HGVSg.
+     * @method
+     * @name OncoKbAPI#annotateMutationsByHGVSgPostUsingPOST_1
+     * @param {} body - List of queries. Please see swagger.json for request body format.
+     */
+    annotateMutationsByHGVSgPostUsingPOST_1(parameters: {
+            'body': Array < AnnotateMutationByHGVSgQuery > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GermlineIndicatorQueryResp >
+        > {
+            return this.annotateMutationsByHGVSgPostUsingPOST_1WithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };
@@ -2233,555 +2779,9 @@ export default class OncoKbAPI {
             'limit' ? : number,
             $queryParameters ? : any,
             $domain ? : string
-        }): Promise < Array < AnnotationSearchResult >
+        }): Promise < Array < SomaticAnnotationSearchResult >
         > {
             return this.annotationSearchGetUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-    annotateMutationsByGenomicChangeGetUsingGET_1URL(parameters: {
-        'genomicLocation': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/v1/annotate/germline/mutations/byGenomicChange';
-        if (parameters['genomicLocation'] !== undefined) {
-            queryParameters['genomicLocation'] = parameters['genomicLocation'];
-        }
-
-        if (parameters['referenceGenome'] !== undefined) {
-            queryParameters['referenceGenome'] = parameters['referenceGenome'];
-        }
-
-        if (parameters['tumorType'] !== undefined) {
-            queryParameters['tumorType'] = parameters['tumorType'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Annotate mutation by genomic change.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByGenomicChangeGetUsingGET_1
-     * @param {string} genomicLocation - Genomic location following TCGA MAF format. Example: 7,140453136,140453136,A,T
-     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
-     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
-     */
-    annotateMutationsByGenomicChangeGetUsingGET_1WithHttpInfo(parameters: {
-        'genomicLocation': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/v1/annotate/germline/mutations/byGenomicChange';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            if (parameters['genomicLocation'] !== undefined) {
-                queryParameters['genomicLocation'] = parameters['genomicLocation'];
-            }
-
-            if (parameters['genomicLocation'] === undefined) {
-                reject(new Error('Missing required  parameter: genomicLocation'));
-                return;
-            }
-
-            if (parameters['referenceGenome'] !== undefined) {
-                queryParameters['referenceGenome'] = parameters['referenceGenome'];
-            }
-
-            if (parameters['tumorType'] !== undefined) {
-                queryParameters['tumorType'] = parameters['tumorType'];
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Annotate mutation by genomic change.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByGenomicChangeGetUsingGET_1
-     * @param {string} genomicLocation - Genomic location following TCGA MAF format. Example: 7,140453136,140453136,A,T
-     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
-     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
-     */
-    annotateMutationsByGenomicChangeGetUsingGET_1(parameters: {
-        'genomicLocation': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < GermlineIndicatorQueryResp > {
-        return this.annotateMutationsByGenomicChangeGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
-            return response.body;
-        });
-    };
-    annotateMutationsByGenomicChangePostUsingPOST_1URL(parameters: {
-        'body': Array < AnnotateMutationByGenomicChangeQuery > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/v1/annotate/germline/mutations/byGenomicChange';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Annotate mutations by genomic change.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByGenomicChangePostUsingPOST_1
-     * @param {} body - List of queries. Please see swagger.json for request body format.
-     */
-    annotateMutationsByGenomicChangePostUsingPOST_1WithHttpInfo(parameters: {
-        'body': Array < AnnotateMutationByGenomicChangeQuery > ,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/v1/annotate/germline/mutations/byGenomicChange';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            if (parameters['body'] !== undefined) {
-                body = parameters['body'];
-            }
-
-            if (parameters['body'] === undefined) {
-                reject(new Error('Missing required  parameter: body'));
-                return;
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Annotate mutations by genomic change.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByGenomicChangePostUsingPOST_1
-     * @param {} body - List of queries. Please see swagger.json for request body format.
-     */
-    annotateMutationsByGenomicChangePostUsingPOST_1(parameters: {
-            'body': Array < AnnotateMutationByGenomicChangeQuery > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < GermlineIndicatorQueryResp >
-        > {
-            return this.annotateMutationsByGenomicChangePostUsingPOST_1WithHttpInfo(parameters).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-    annotateMutationsByHGVScGetUsingGET_1URL(parameters: {
-        'hgvsc': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/v1/annotate/germline/mutations/byHGVSc';
-        if (parameters['hgvsc'] !== undefined) {
-            queryParameters['hgvsc'] = parameters['hgvsc'];
-        }
-
-        if (parameters['referenceGenome'] !== undefined) {
-            queryParameters['referenceGenome'] = parameters['referenceGenome'];
-        }
-
-        if (parameters['tumorType'] !== undefined) {
-            queryParameters['tumorType'] = parameters['tumorType'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Annotate mutation by HGVSc.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVScGetUsingGET_1
-     * @param {string} hgvsc - HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T
-     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
-     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
-     */
-    annotateMutationsByHGVScGetUsingGET_1WithHttpInfo(parameters: {
-        'hgvsc': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/v1/annotate/germline/mutations/byHGVSc';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            if (parameters['hgvsc'] !== undefined) {
-                queryParameters['hgvsc'] = parameters['hgvsc'];
-            }
-
-            if (parameters['hgvsc'] === undefined) {
-                reject(new Error('Missing required  parameter: hgvsc'));
-                return;
-            }
-
-            if (parameters['referenceGenome'] !== undefined) {
-                queryParameters['referenceGenome'] = parameters['referenceGenome'];
-            }
-
-            if (parameters['tumorType'] !== undefined) {
-                queryParameters['tumorType'] = parameters['tumorType'];
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Annotate mutation by HGVSc.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVScGetUsingGET_1
-     * @param {string} hgvsc - HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T
-     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
-     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
-     */
-    annotateMutationsByHGVScGetUsingGET_1(parameters: {
-        'hgvsc': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < GermlineIndicatorQueryResp > {
-        return this.annotateMutationsByHGVScGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
-            return response.body;
-        });
-    };
-    annotateMutationsByHGVScPostUsingPOST_1URL(parameters: {
-        'body': Array < AnnotateMutationByHGVScQuery > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/v1/annotate/germline/mutations/byHGVSc';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Annotate mutations by HGVSc.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVScPostUsingPOST_1
-     * @param {} body - List of queries. Please see swagger.json for request body format.
-     */
-    annotateMutationsByHGVScPostUsingPOST_1WithHttpInfo(parameters: {
-        'body': Array < AnnotateMutationByHGVScQuery > ,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/v1/annotate/germline/mutations/byHGVSc';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            if (parameters['body'] !== undefined) {
-                body = parameters['body'];
-            }
-
-            if (parameters['body'] === undefined) {
-                reject(new Error('Missing required  parameter: body'));
-                return;
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Annotate mutations by HGVSc.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVScPostUsingPOST_1
-     * @param {} body - List of queries. Please see swagger.json for request body format.
-     */
-    annotateMutationsByHGVScPostUsingPOST_1(parameters: {
-            'body': Array < AnnotateMutationByHGVScQuery > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < GermlineIndicatorQueryResp >
-        > {
-            return this.annotateMutationsByHGVScPostUsingPOST_1WithHttpInfo(parameters).then(function(response: request.Response) {
-                return response.body;
-            });
-        };
-    annotateMutationsByHGVSgGetUsingGET_1URL(parameters: {
-        'hgvsg': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/v1/annotate/germline/mutations/byHGVSg';
-        if (parameters['hgvsg'] !== undefined) {
-            queryParameters['hgvsg'] = parameters['hgvsg'];
-        }
-
-        if (parameters['referenceGenome'] !== undefined) {
-            queryParameters['referenceGenome'] = parameters['referenceGenome'];
-        }
-
-        if (parameters['tumorType'] !== undefined) {
-            queryParameters['tumorType'] = parameters['tumorType'];
-        }
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Annotate mutation by HGVSg.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVSgGetUsingGET_1
-     * @param {string} hgvsg - HGVS genomic format following HGVS nomenclature. Example: 7:g.140453136A>T
-     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
-     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
-     */
-    annotateMutationsByHGVSgGetUsingGET_1WithHttpInfo(parameters: {
-        'hgvsg': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/v1/annotate/germline/mutations/byHGVSg';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            if (parameters['hgvsg'] !== undefined) {
-                queryParameters['hgvsg'] = parameters['hgvsg'];
-            }
-
-            if (parameters['hgvsg'] === undefined) {
-                reject(new Error('Missing required  parameter: hgvsg'));
-                return;
-            }
-
-            if (parameters['referenceGenome'] !== undefined) {
-                queryParameters['referenceGenome'] = parameters['referenceGenome'];
-            }
-
-            if (parameters['tumorType'] !== undefined) {
-                queryParameters['tumorType'] = parameters['tumorType'];
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('GET', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Annotate mutation by HGVSg.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVSgGetUsingGET_1
-     * @param {string} hgvsg - HGVS genomic format following HGVS nomenclature. Example: 7:g.140453136A>T
-     * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
-     * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
-     */
-    annotateMutationsByHGVSgGetUsingGET_1(parameters: {
-        'hgvsg': string,
-        'referenceGenome' ? : string,
-        'tumorType' ? : string,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < GermlineIndicatorQueryResp > {
-        return this.annotateMutationsByHGVSgGetUsingGET_1WithHttpInfo(parameters).then(function(response: request.Response) {
-            return response.body;
-        });
-    };
-    annotateMutationsByHGVSgPostUsingPOST_1URL(parameters: {
-        'body': Array < AnnotateMutationByHGVSgQuery > ,
-        $queryParameters ? : any
-    }): string {
-        let queryParameters: any = {};
-        let path = '/api/v1/annotate/germline/mutations/byHGVSg';
-
-        if (parameters.$queryParameters) {
-            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                var parameter = parameters.$queryParameters[parameterName];
-                queryParameters[parameterName] = parameter;
-            });
-        }
-        let keys = Object.keys(queryParameters);
-        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
-    };
-
-    /**
-     * Annotate mutations by HGVSg.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVSgPostUsingPOST_1
-     * @param {} body - List of queries. Please see swagger.json for request body format.
-     */
-    annotateMutationsByHGVSgPostUsingPOST_1WithHttpInfo(parameters: {
-        'body': Array < AnnotateMutationByHGVSgQuery > ,
-        $queryParameters ? : any,
-        $domain ? : string
-    }): Promise < request.Response > {
-        const domain = parameters.$domain ? parameters.$domain : this.domain;
-        const errorHandlers = this.errorHandlers;
-        const request = this.request;
-        let path = '/api/v1/annotate/germline/mutations/byHGVSg';
-        let body: any;
-        let queryParameters: any = {};
-        let headers: any = {};
-        let form: any = {};
-        return new Promise(function(resolve, reject) {
-            headers['Accept'] = 'application/json';
-            headers['Content-Type'] = 'application/json';
-
-            if (parameters['body'] !== undefined) {
-                body = parameters['body'];
-            }
-
-            if (parameters['body'] === undefined) {
-                reject(new Error('Missing required  parameter: body'));
-                return;
-            }
-
-            if (parameters.$queryParameters) {
-                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
-                    var parameter = parameters.$queryParameters[parameterName];
-                    queryParameters[parameterName] = parameter;
-                });
-            }
-
-            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
-
-        });
-    };
-
-    /**
-     * Annotate mutations by HGVSg.
-     * @method
-     * @name OncoKbAPI#annotateMutationsByHGVSgPostUsingPOST_1
-     * @param {} body - List of queries. Please see swagger.json for request body format.
-     */
-    annotateMutationsByHGVSgPostUsingPOST_1(parameters: {
-            'body': Array < AnnotateMutationByHGVSgQuery > ,
-            $queryParameters ? : any,
-            $domain ? : string
-        }): Promise < Array < GermlineIndicatorQueryResp >
-        > {
-            return this.annotateMutationsByHGVSgPostUsingPOST_1WithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
@@ -68,15 +68,15 @@ export type ApiHttpError = {
 
 };
 export type LevelInfo = {
-    'highestDiagnosticLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+    'highestDiagnosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestFDALevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
+        'highestFDALevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestPrognosticLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+        'highestPrognosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
 };
 export type ParsedVersionInfo = {

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
@@ -28,7 +28,7 @@ export type OncogenicityEntity = {
 export type Query = {
     'alteration': string
 
-        'alterationType': "MUTATION" | "COPY_NUMBER_ALTERATION" | "STRUCTURAL_VARIANT"
+        'alterationType': "MUTATION" | "COPY_NUMBER_ALTERATION" | "STRUCTURAL_VARIANT" | null
 
         'canonicalTranscript': string
 
@@ -50,7 +50,7 @@ export type Query = {
 
         'referenceGenome': "GRCh37" | "GRCh38"
 
-        'svType': "DELETION" | "TRANSLOCATION" | "DUPLICATION" | "INSERTION" | "INVERSION" | "FUSION" | "UNKNOWN"
+        'svType': "DELETION" | "TRANSLOCATION" | "DUPLICATION" | "INSERTION" | "INVERSION" | "FUSION" | "UNKNOWN" | null
 
         'tumorType': string
 
@@ -482,15 +482,15 @@ export type SomaticIndicatorQueryResp = {
 
         'geneSummary': string
 
-        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | null
 
-        'highestFdaLevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
+        'highestFdaLevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | null
 
-        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | null
 
-        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2" | null
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | null
 
         'hotspot': boolean
 
@@ -546,13 +546,13 @@ export type GermlineIndicatorQueryResp = {
 
         'genomicIndicators': Array < GenomicIndicator >
 
-        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | null
 
-        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | null
 
-        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2" | null
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | null
 
         'lastUpdate': string
 

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json
@@ -2303,48 +2303,112 @@
       "properties": {
         "highestDiagnosticLevel": {
           "type": "string",
-          "description": "(Nullable) The highest diagnostic level from this tag's diagnostic evidences.",
-          "enum": [
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3"
-          ]
-        },
-        "highestFDALevel": {
-          "type": "string",
-          "description": "(Nullable) The highest FDA level from this tag's therapeutic evidences.",
-          "enum": [
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3"
-          ]
-        },
-        "highestPrognosticLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest prognostic level from this tag's prognostic evidences.",
-          "enum": [
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3"
-          ]
-        },
-        "highestResistanceLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest resistance level from this tag's therapeutic evidences.",
-          "enum": [
-            "LEVEL_R1",
-            "LEVEL_R2"
-          ]
-        },
-        "highestSensitiveLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest sensitivity level from this tag's therapeutic evidences.",
           "enum": [
             "LEVEL_1",
             "LEVEL_2",
             "LEVEL_3A",
             "LEVEL_3B",
-            "LEVEL_4"
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestFDALevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestPrognosticLevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestResistanceLevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
+          ]
+        },
+        "highestSensitiveLevel": {
+          "type": "string",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4",
+            "LEVEL_R1",
+            "LEVEL_R2",
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3",
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3",
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3",
+            "NO"
           ]
         }
       }

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "OncoKB, a comprehensive and curated precision oncology knowledge base, offers oncologists detailed, evidence-based information about individual somatic mutations and structural alterations present in patient tumors with the goal of supporting optimal treatment decisions.",
-    "version": "v1.5.0",
+    "version": "v1.6.0",
     "title": "OncoKB APIs",
     "contact": {
       "name": "OncoKB",
@@ -570,7 +570,7 @@
         }
       }
     },
-     "/tags/{hugoSymbol}/{name}/{tumorType}": {
+    "/tags/{hugoSymbol}/{name}/{tumorType}": {
       "get": {
         "tags": [
           "tags-controller"
@@ -2095,6 +2095,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -2105,6 +2106,9 @@
         },
         "genomicLocation": {
           "type": "string"
+        },
+        "germline": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -2294,6 +2298,96 @@
         }
       }
     },
+    "LevelInfo": {
+      "type": "object",
+      "properties": {
+        "highestDiagnosticLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest diagnostic level from this tag's diagnostic evidences.",
+          "enum": [
+            "LEVEL_Dx1",
+            "LEVEL_Dx2",
+            "LEVEL_Dx3"
+          ]
+        },
+        "highestFDALevel": {
+          "type": "string",
+          "description": "(Nullable) The highest FDA level from this tag's therapeutic evidences.",
+          "enum": [
+            "LEVEL_Fda1",
+            "LEVEL_Fda2",
+            "LEVEL_Fda3"
+          ]
+        },
+        "highestPrognosticLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest prognostic level from this tag's prognostic evidences.",
+          "enum": [
+            "LEVEL_Px1",
+            "LEVEL_Px2",
+            "LEVEL_Px3"
+          ]
+        },
+        "highestResistanceLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest resistance level from this tag's therapeutic evidences.",
+          "enum": [
+            "LEVEL_R1",
+            "LEVEL_R2"
+          ]
+        },
+        "highestSensitiveLevel": {
+          "type": "string",
+          "description": "(Nullable) The highest sensitivity level from this tag's therapeutic evidences.",
+          "enum": [
+            "LEVEL_1",
+            "LEVEL_2",
+            "LEVEL_3A",
+            "LEVEL_3B",
+            "LEVEL_4"
+          ]
+        }
+      }
+    },
+    "MainNumber": {
+      "type": "object",
+      "properties": {
+        "alteration": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "drug": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "gene": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "level": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MainNumberLevel"
+          }
+        },
+        "tumorType": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "CancerTypeCount": {
+      "type": "object",
+      "properties": {
+        "cancerType": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "Implication": {
       "type": "object",
       "properties": {
@@ -2354,14 +2448,6 @@
     "GermlineVariantAnnotation": {
       "type": "object",
       "properties": {
-        "alleleExist": {
-          "type": "boolean",
-          "example": false,
-          "description": "Indicates whether the alternate allele has been curated. See SOP Protocol 9.1"
-        },
-        "clinVarId": {
-          "type": "string"
-        },
         "dataVersion": {
           "type": "string",
           "example": "v4.25",
@@ -2377,10 +2463,6 @@
         "diagnosticSummary": {
           "type": "string",
           "description": "Diagnostic summary. Defaulted to \"\""
-        },
-        "exon": {
-          "type": "string",
-          "description": "(Nullable) The affected exon of this variant, if applicable (currently only supported when annotating via HGVSg or Genomic Location)"
         },
         "geneExist": {
           "type": "boolean",
@@ -2401,92 +2483,26 @@
           "type": "string",
           "description": "(Nullable) The highest diagnostic level from a list of diagnostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
             "LEVEL_Dx1",
             "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestFdaLevel": {
-          "type": "string",
-          "description": "(Nullable) The highest FDA level from a list of therapeutic evidences.",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Dx3"
           ]
         },
         "highestPrognosticImplicationLevel": {
           "type": "string",
           "description": "(Nullable) The highest prognostic level from a list of prognostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
             "LEVEL_Px1",
             "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Px3"
           ]
         },
         "highestResistanceLevel": {
           "type": "string",
           "description": "(Nullable) The highest resistance level from a list of therapeutic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
             "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_R2"
           ]
         },
         "highestSensitiveLevel": {
@@ -2497,19 +2513,7 @@
             "LEVEL_2",
             "LEVEL_3A",
             "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_4"
           ]
         },
         "lastUpdate": {
@@ -2520,63 +2524,13 @@
         "mutationEffect": {
           "$ref": "#/definitions/MutationEffectResp"
         },
-        "otherSignificantResistanceLevels": {
-          "type": "array",
-          "description": "DEPRECATED",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
-        "otherSignificantSensitiveLevels": {
-          "type": "array",
-          "description": "DEPRECATED",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
         "pathogenic": {
-          "type": "string"
+          "type": "string",
+          "description": "(Nullable) The classification of the likelihood that a germline variant will cause disease."
         },
         "penetrance": {
-          "type": "string"
+          "type": "string",
+          "description": "(Nullable) The likelihood that individuals with a specific variant will become affected"
         },
         "prognosticImplications": {
           "type": "array",
@@ -2602,6 +2556,12 @@
         "tumorTypeSummary": {
           "type": "string",
           "description": "Tumor type summary. Defaulted to \"\""
+        },
+        "tumorTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VariantAnnotationTumorType"
+          }
         },
         "variantExist": {
           "type": "boolean",
@@ -2943,10 +2903,12 @@
       "type": "object",
       "properties": {
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the genomic indicator"
         },
         "inheritanceMechanism": {
           "type": "string",
+          "description": "Describes how a genetic trait/allele may be passed to offspring",
           "enum": [
             "AUTOSOMAL_DOMINANT",
             "AUTOSOMAL_RECESSIVE",
@@ -2955,9 +2917,11 @@
           ]
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the clinical syndrome"
         }
-      }
+      },
+      "description": "clinical syndromes associated with specific germline variants/alleles that describe the clinical consequences associated with that variant"
     },
     "TumorTypeEntity": {
       "type": "object",
@@ -3107,406 +3071,6 @@
         }
       }
     },
-    "LevelInfo": {
-      "type": "object",
-      "properties": {
-        "highestDiagnosticLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestFDALevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestPrognosticLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestResistanceLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestSensitiveLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        }
-      }
-    },
-    "MainNumber": {
-      "type": "object",
-      "properties": {
-        "alteration": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "drug": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "gene": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "level": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MainNumberLevel"
-          }
-        },
-        "tumorType": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "CancerTypeCount": {
-      "type": "object",
-      "properties": {
-        "cancerType": {
-          "type": "string"
-        },
-        "count": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "VariantAnnotation": {
-      "type": "object",
-      "properties": {
-        "alleleExist": {
-          "type": "boolean"
-        },
-        "alteration": {
-          "$ref": "#/definitions/Alteration"
-        },
-        "background": {
-          "type": "string"
-        },
-        "dataVersion": {
-          "type": "string"
-        },
-        "diagnosticImplications": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Implication"
-          }
-        },
-        "diagnosticSummary": {
-          "type": "string"
-        },
-        "geneExist": {
-          "type": "boolean"
-        },
-        "geneSummary": {
-          "type": "string"
-        },
-        "germline": {
-          "$ref": "#/definitions/GermlineVariant"
-        },
-        "highestDiagnosticImplicationLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestFdaLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestPrognosticImplicationLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestResistanceLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "highestSensitiveLevel": {
-          "type": "string",
-          "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
-          ]
-        },
-        "hotspot": {
-          "type": "boolean"
-        },
-        "lastUpdate": {
-          "type": "string"
-        },
-        "mutationEffect": {
-          "$ref": "#/definitions/MutationEffectResp"
-        },
-        "oncogenic": {
-          "type": "string"
-        },
-        "otherSignificantResistanceLevels": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
-        "otherSignificantSensitiveLevels": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "LEVEL_1",
-              "LEVEL_2",
-              "LEVEL_3A",
-              "LEVEL_3B",
-              "LEVEL_4",
-              "LEVEL_R1",
-              "LEVEL_R2",
-              "LEVEL_Px1",
-              "LEVEL_Px2",
-              "LEVEL_Px3",
-              "LEVEL_Dx1",
-              "LEVEL_Dx2",
-              "LEVEL_Dx3",
-              "LEVEL_Fda1",
-              "LEVEL_Fda2",
-              "LEVEL_Fda3",
-              "NO"
-            ]
-          }
-        },
-        "prognosticImplications": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Implication"
-          }
-        },
-        "prognosticSummary": {
-          "type": "string"
-        },
-        "query": {
-          "$ref": "#/definitions/Query"
-        },
-        "treatments": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/IndicatorQueryTreatment"
-          }
-        },
-        "tumorTypeSummary": {
-          "type": "string"
-        },
-        "tumorTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/VariantAnnotationTumorType"
-          }
-        },
-        "variantExist": {
-          "type": "boolean"
-        },
-        "variantSummary": {
-          "type": "string"
-        },
-        "vue": {
-          "type": "boolean"
-        },
-        "vus": {
-          "type": "boolean"
-        }
-      }
-    },
     "AnnotatedVariant": {
       "type": "object",
       "properties": {
@@ -3548,6 +3112,9 @@
           "type": "string"
         },
         "referenceGenome": {
+          "type": "string"
+        },
+        "setting": {
           "type": "string"
         },
         "variant": {
@@ -3672,10 +3239,6 @@
             "type": "string"
           }
         },
-        "evidenceId": {
-          "type": "integer",
-          "format": "int32"
-        },
         "excludedCancerTypes": {
           "type": "array",
           "items": {
@@ -3696,6 +3259,9 @@
         },
         "solidPropagationLevel": {
           "type": "string"
+        },
+        "tag": {
+          "$ref": "#/definitions/Tag"
         },
         "variant": {
           "$ref": "#/definitions/Alteration"
@@ -3779,6 +3345,7 @@
             "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
             "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
             "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+            "TX_ADDENDUM",
             "PATHOGENIC",
             "GENOMIC_INDICATOR",
             "GENE_PENETRANCE",
@@ -4345,7 +3912,19 @@
         },
         "knownEffect": {
           "type": "string",
-          "description": "Indicates the effect of the mutation on the gene. Defaulted to \"\""
+          "description": "Indicates the effect of the mutation on the gene. Defaulted to \"\"",
+          "enum": [
+            "Gain-of-function",
+            "Inconclusive",
+            "Loss-of-function",
+            "Likely Loss-of-function",
+            "Likely Gain-of-function",
+            "Neutral",
+            "Unknown",
+            "Likely Switch-of-function",
+            "Switch-of-function",
+            "Likely Neutral"
+          ]
         }
       }
     },
@@ -4373,6 +3952,7 @@
               "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY",
               "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE",
+              "TX_ADDENDUM",
               "PATHOGENIC",
               "GENOMIC_INDICATOR",
               "GENE_PENETRANCE",
@@ -4380,6 +3960,9 @@
               "VARIANT_CANCER_RISK"
             ]
           }
+        },
+        "germline": {
+          "type": "boolean"
         },
         "hgvsg": {
           "type": "string"
@@ -4399,7 +3982,7 @@
         }
       }
     },
-     "Tag": {
+    "Tag": {
       "type": "object",
       "properties": {
         "description": {
@@ -4511,7 +4094,7 @@
         },
         "exon": {
           "type": "string",
-          "description": "(Nullable) The affected exon of this variant, if applicable (currently only supported when annotating via HGVSg or Genomic Location)"
+          "description": "DEPRECATED. (Nullable) The affected exon of this variant, if applicable (currently only supported when annotating via HGVSg or Genomic Location)"
         },
         "geneExist": {
           "type": "boolean",
@@ -4526,92 +4109,35 @@
           "type": "string",
           "description": "(Nullable) The highest diagnostic level from a list of diagnostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
             "LEVEL_Dx1",
             "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Dx3"
           ]
         },
         "highestFdaLevel": {
           "type": "string",
           "description": "(Nullable) The highest FDA level from a list of therapeutic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
             "LEVEL_Fda1",
             "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Fda3"
           ]
         },
         "highestPrognosticImplicationLevel": {
           "type": "string",
           "description": "(Nullable) The highest prognostic level from a list of prognostic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
             "LEVEL_Px1",
             "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_Px3"
           ]
         },
         "highestResistanceLevel": {
           "type": "string",
           "description": "(Nullable) The highest resistance level from a list of therapeutic evidences.",
           "enum": [
-            "LEVEL_1",
-            "LEVEL_2",
-            "LEVEL_3A",
-            "LEVEL_3B",
-            "LEVEL_4",
             "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_R2"
           ]
         },
         "highestSensitiveLevel": {
@@ -4622,19 +4148,7 @@
             "LEVEL_2",
             "LEVEL_3A",
             "LEVEL_3B",
-            "LEVEL_4",
-            "LEVEL_R1",
-            "LEVEL_R2",
-            "LEVEL_Px1",
-            "LEVEL_Px2",
-            "LEVEL_Px3",
-            "LEVEL_Dx1",
-            "LEVEL_Dx2",
-            "LEVEL_Dx3",
-            "LEVEL_Fda1",
-            "LEVEL_Fda2",
-            "LEVEL_Fda3",
-            "NO"
+            "LEVEL_4"
           ]
         },
         "hotspot": {
@@ -4652,7 +4166,15 @@
         },
         "oncogenic": {
           "type": "string",
-          "description": "The oncogenicity status of the variant. Defaulted to \"Unknown\"."
+          "description": "The oncogenicity status of the variant. Defaulted to \"Unknown\".",
+          "enum": [
+            "Oncogenic",
+            "Likely Oncogenic",
+            "Likely Neutral",
+            "Inconclusive",
+            "Resistance",
+            "Unknown"
+          ]
         },
         "otherSignificantResistanceLevels": {
           "type": "array",

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
@@ -38,7 +38,7 @@ export type OncogenicityEntity = {
 export type Query = {
     'alteration': string
 
-        'alterationType': "MUTATION" | "COPY_NUMBER_ALTERATION" | "STRUCTURAL_VARIANT"
+        'alterationType': "MUTATION" | "COPY_NUMBER_ALTERATION" | "STRUCTURAL_VARIANT" | null
 
         'canonicalTranscript': string
 
@@ -60,7 +60,7 @@ export type Query = {
 
         'referenceGenome': "GRCh37" | "GRCh38"
 
-        'svType': "DELETION" | "TRANSLOCATION" | "DUPLICATION" | "INSERTION" | "INVERSION" | "FUSION" | "UNKNOWN"
+        'svType': "DELETION" | "TRANSLOCATION" | "DUPLICATION" | "INSERTION" | "INVERSION" | "FUSION" | "UNKNOWN" | null
 
         'tumorType': string
 
@@ -140,13 +140,13 @@ export type GermlineVariantAnnotation = {
 
         'genomicIndicators': Array < GenomicIndicator >
 
-        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | null
 
-        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | null
 
-        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2" | null
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | null
 
         'lastUpdate': string
 
@@ -794,15 +794,15 @@ export type SomaticVariantAnnotation = {
 
         'geneSummary': string
 
-        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | null
 
-        'highestFdaLevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
+        'highestFdaLevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | null
 
-        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | null
 
-        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2" | null
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | null
 
         'hotspot': boolean
 

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
@@ -2,9 +2,11 @@ import * as request from "superagent";
 
 type CallbackHandler = (err: any, res ? : request.Response) => void;
 export type AnnotateMutationByGenomicChangeQuery = {
-    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
 
         'genomicLocation': string
+
+        'germline': boolean
 
         'id': string
 
@@ -36,7 +38,7 @@ export type OncogenicityEntity = {
 export type Query = {
     'alteration': string
 
-        'alterationType': string
+        'alterationType': "MUTATION" | "COPY_NUMBER_ALTERATION" | "STRUCTURAL_VARIANT"
 
         'canonicalTranscript': string
 
@@ -81,6 +83,36 @@ export type ApiHttpError = {
         'title': string
 
 };
+export type LevelInfo = {
+    'highestDiagnosticLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+
+        'highestFDALevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
+
+        'highestPrognosticLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+
+};
+export type MainNumber = {
+    'alteration': number
+
+        'drug': number
+
+        'gene': number
+
+        'level': Array < MainNumberLevel >
+
+        'tumorType': number
+
+};
+export type CancerTypeCount = {
+    'cancerType': string
+
+        'count': number
+
+};
 export type Implication = {
     'abstracts': Array < ArticleAbstract >
 
@@ -96,17 +128,11 @@ export type Implication = {
 
 };
 export type GermlineVariantAnnotation = {
-    'alleleExist': boolean
-
-        'clinVarId': string
-
-        'dataVersion': string
+    'dataVersion': string
 
         'diagnosticImplications': Array < Implication >
 
         'diagnosticSummary': string
-
-        'exon': string
 
         'geneExist': boolean
 
@@ -114,23 +140,17 @@ export type GermlineVariantAnnotation = {
 
         'genomicIndicators': Array < GenomicIndicator >
 
-        'highestDiagnosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
 
-        'highestFdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
 
-        'highestPrognosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
 
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
 
         'lastUpdate': string
 
         'mutationEffect': MutationEffectResp
-
-        'otherSignificantResistanceLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
-
-        'otherSignificantSensitiveLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
 
         'pathogenic': string
 
@@ -144,9 +164,9 @@ export type GermlineVariantAnnotation = {
 
         'treatments': Array < IndicatorQueryTreatment >
 
-        'tumorTypes': Array < VariantAnnotationTumorType >
-
         'tumorTypeSummary': string
+
+        'tumorTypes': Array < VariantAnnotationTumorType >
 
         'variantExist': boolean
 
@@ -175,7 +195,28 @@ export type Gene = {
         'hugoSymbol': string
 
 };
+export type TumorType = {
+    'children': {}
 
+    'code': string
+
+        'color': string
+
+        'id': number
+
+        'level': number
+
+        'mainType': MainType
+
+        'name': string
+
+        'parent': string
+
+        'tissue': string
+
+        'tumorForm': "SOLID" | "LIQUID" | "MIXED"
+
+};
 export type EnsemblTranscript = {
     'ccdsId': string
 
@@ -276,7 +317,7 @@ export type GenomicIndicator = {
         'name': string
 
 };
-export type TumorType = {
+export type TumorTypeEntity = {
     'code': string
 
         'color': string
@@ -358,96 +399,6 @@ export type DownloadAvailability = {
         'version': string
 
 };
-export type LevelInfo = {
-    'highestDiagnosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestFDALevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestPrognosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-};
-export type MainNumber = {
-    'alteration': number
-
-        'drug': number
-
-        'gene': number
-
-        'level': Array < MainNumberLevel >
-
-        'tumorType': number
-
-};
-export type CancerTypeCount = {
-    'cancerType': string
-
-        'count': number
-
-};
-export type VariantAnnotation = {
-    'alleleExist': boolean
-
-        'alteration': Alteration
-
-        'background': string
-
-        'dataVersion': string
-
-        'diagnosticImplications': Array < Implication >
-
-        'diagnosticSummary': string
-
-        'geneExist': boolean
-
-        'geneSummary': string
-
-        'highestDiagnosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestFdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestPrognosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
-
-        'hotspot': boolean
-
-        'lastUpdate': string
-
-        'mutationEffect': MutationEffectResp
-
-        'oncogenic': string
-
-        'otherSignificantResistanceLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
-
-        'otherSignificantSensitiveLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
-
-        'prognosticImplications': Array < Implication >
-
-        'prognosticSummary': string
-
-        'query': Query
-
-        'treatments': Array < IndicatorQueryTreatment >
-
-        'tumorTypeSummary': string
-
-        'tumorTypes': Array < VariantAnnotationTumorType >
-
-        'variantExist': boolean
-
-        'variantSummary': string
-
-        'vue': boolean
-
-        'vus': boolean
-
-};
 export type AnnotatedVariant = {
     'description': string
 
@@ -474,6 +425,8 @@ export type AnnotatedVariant = {
         'proteinChange': string
 
         'referenceGenome': string
+
+        'setting': string
 
         'variant': string
 
@@ -505,7 +458,7 @@ export type Exon = {
 
 };
 export type ClinicalVariant = {
-    'cancerTypes': Array < TumorType >
+    'cancerTypes': Array < TumorTypeEntity >
 
         'drug': Array < string >
 
@@ -515,9 +468,7 @@ export type ClinicalVariant = {
 
         'drugPmids': Array < string >
 
-        'evidenceId': number
-
-        'excludedCancerTypes': Array < TumorType >
+        'excludedCancerTypes': Array < TumorTypeEntity >
 
         'fdaLevel': string
 
@@ -528,6 +479,8 @@ export type ClinicalVariant = {
         'oncogenic': string
 
         'solidPropagationLevel': string
+
+        'tag': Tag
 
         'variant': Alteration
 
@@ -557,13 +510,13 @@ export type Evidence = {
 
         'articles': Array < Article >
 
-        'cancerTypes': Array < TumorType >
+        'cancerTypes': Array < TumorTypeEntity >
 
         'description': string
 
-        'evidenceType': "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK"
+        'evidenceType': "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK"
 
-        'excludedCancerTypes': Array < TumorType >
+        'excludedCancerTypes': Array < TumorTypeEntity >
 
         'fdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
@@ -583,7 +536,7 @@ export type Evidence = {
 
         'name': string
 
-        'relevantCancerTypes': Array < TumorType >
+        'relevantCancerTypes': Array < TumorTypeEntity >
 
         'solidPropagationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
@@ -639,7 +592,7 @@ export type TypeaheadSearchResp = {
 
         'queryType': "GENE" | "VARIANT" | "DRUG" | "TEXT" | "GENOMIC" | "CANCER_TYPE"
 
-        'tumorTypes': Array < TumorType >
+        'tumorTypes': Array < TumorTypeEntity >
 
         'variantExist': boolean
 
@@ -653,7 +606,7 @@ export type VariantAnnotationTumorType = {
 
         'relevantTumorType': boolean
 
-        'tumorType': TumorType
+        'tumorType': TumorTypeEntity
 
 };
 export type ArticleAbstract = {
@@ -771,11 +724,13 @@ export type MutationEffectResp = {
 
         'description': string
 
-        'knownEffect': string
+        'knownEffect': "Gain-of-function" | "Inconclusive" | "Loss-of-function" | "Likely Loss-of-function" | "Likely Gain-of-function" | "Neutral" | "Unknown" | "Likely Switch-of-function" | "Switch-of-function" | "Likely Neutral"
 
 };
 export type AnnotateMutationByHGVSgQuery = {
-    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+    'evidenceTypes': Array < "GENE_SUMMARY" | "MUTATION_SUMMARY" | "TUMOR_TYPE_SUMMARY" | "GENE_TUMOR_TYPE_SUMMARY" | "PROGNOSTIC_SUMMARY" | "DIAGNOSTIC_SUMMARY" | "GENE_BACKGROUND" | "ONCOGENIC" | "MUTATION_EFFECT" | "VUS" | "PROGNOSTIC_IMPLICATION" | "DIAGNOSTIC_IMPLICATION" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY" | "STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_SENSITIVITY" | "INVESTIGATIONAL_THERAPEUTIC_IMPLICATIONS_DRUG_RESISTANCE" | "TX_ADDENDUM" | "PATHOGENIC" | "GENOMIC_INDICATOR" | "GENE_PENETRANCE" | "VARIANT_PENETRANCE" | "VARIANT_CANCER_RISK" >
+
+        'germline': boolean
 
         'hgvsg': string
 
@@ -839,15 +794,15 @@ export type SomaticVariantAnnotation = {
 
         'geneSummary': string
 
-        'highestDiagnosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestDiagnosticImplicationLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
 
-        'highestFdaLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestFdaLevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
 
-        'highestPrognosticImplicationLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestPrognosticImplicationLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
 
-        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
 
         'hotspot': boolean
 
@@ -855,7 +810,7 @@ export type SomaticVariantAnnotation = {
 
         'mutationEffect': MutationEffectResp
 
-        'oncogenic': string
+        'oncogenic': "Oncogenic" | "Likely Oncogenic" | "Likely Neutral" | "Inconclusive" | "Resistance" | "Unknown"
 
         'otherSignificantResistanceLevels': Array < "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO" >
 
@@ -3449,7 +3404,7 @@ export default class OncoKbPrivateAPI {
             'body': Array < RelevantCancerTypeQuery > ,
                 $queryParameters ? : any,
                 $domain ? : string
-        }): Promise < Array < TumorType >
+        }): Promise < Array < TumorTypeEntity >
         > {
             return this.utilRelevantCancerTypesPostUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
@@ -3524,7 +3479,7 @@ export default class OncoKbPrivateAPI {
             'tumorType' ? : string,
             $queryParameters ? : any,
                 $domain ? : string
-        }): Promise < Array < TumorType >
+        }): Promise < Array < TumorTypeEntity >
         > {
             return this.utilRelevantTumorTypesGetUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
@@ -3650,7 +3605,7 @@ export default class OncoKbPrivateAPI {
     utilsTumorTypesGetUsingGET(parameters: {
             $queryParameters ? : any,
                 $domain ? : string
-        }): Promise < Array < TumorType >
+        }): Promise < Array < TumorTypeEntity >
         > {
             return this.utilsTumorTypesGetUsingGETWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
@@ -84,15 +84,15 @@ export type ApiHttpError = {
 
 };
 export type LevelInfo = {
-    'highestDiagnosticLevel': "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3"
+    'highestDiagnosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestFDALevel': "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3"
+        'highestFDALevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestPrognosticLevel': "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3"
+        'highestPrognosticLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestResistanceLevel': "LEVEL_R1" | "LEVEL_R2"
+        'highestResistanceLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
-        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4"
+        'highestSensitiveLevel': "LEVEL_1" | "LEVEL_2" | "LEVEL_3A" | "LEVEL_3B" | "LEVEL_4" | "LEVEL_R1" | "LEVEL_R2" | "LEVEL_Px1" | "LEVEL_Px2" | "LEVEL_Px3" | "LEVEL_Dx1" | "LEVEL_Dx2" | "LEVEL_Dx3" | "LEVEL_Fda1" | "LEVEL_Fda2" | "LEVEL_Fda3" | "NO"
 
 };
 export type MainNumber = {

--- a/src/main/webapp/app/shared/dropdown/CancerTypeSelect.tsx
+++ b/src/main/webapp/app/shared/dropdown/CancerTypeSelect.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import Select, { Props as SelectProps } from 'react-select';
 import { computed } from 'mobx';
-import { TumorType } from 'app/shared/api/generated/OncoKbPrivateAPI';
+import {
+  TumorType,
+  TumorTypeEntity,
+} from 'app/shared/api/generated/OncoKbPrivateAPI';
 import privateClient from 'app/shared/api/oncokbPrivateClientInstance';
 import { remoteData } from 'cbioportal-frontend-commons';
 import { uniq } from 'app/shared/utils/LodashUtils';
@@ -16,7 +19,7 @@ interface ICancerTypeSelect extends SelectProps {
 export default class CancerTypeSelect extends React.Component<
   ICancerTypeSelect
 > {
-  readonly allCancerTypes = remoteData<TumorType[]>({
+  readonly allCancerTypes = remoteData<TumorTypeEntity[]>({
     await: () => [],
     async invoke() {
       const result = await privateClient.utilsTumorTypesGetUsingGET({});

--- a/src/main/webapp/app/shared/tiles/tile-utils.tsx
+++ b/src/main/webapp/app/shared/tiles/tile-utils.tsx
@@ -125,11 +125,11 @@ export function createHighestLevelOfEvidenceTileProps(
             <div className={classnames('d-flex', 'flex-row')}>
               <HighestLevelEvidence
                 type="Sensitive"
-                level={highestSensitiveLevel}
+                level={highestSensitiveLevel ?? undefined}
               />
               <HighestLevelEvidence
                 type="Resistance"
-                level={highestResistanceLevel}
+                level={highestResistanceLevel ?? undefined}
               />
             </div>
           ),
@@ -140,7 +140,7 @@ export function createHighestLevelOfEvidenceTileProps(
           value: (
             <HighestLevelEvidence
               type="DiagnosticImplication"
-              level={highestDiagnosticImplicationLevel}
+              level={highestDiagnosticImplicationLevel ?? undefined}
             />
           ),
         },
@@ -152,14 +152,19 @@ export function createHighestLevelOfEvidenceTileProps(
           value: (
             <HighestLevelEvidence
               type="PrognosticImplication"
-              level={highestPrognosticImplicationLevel}
+              level={highestPrognosticImplicationLevel ?? undefined}
             />
           ),
         },
         {
           title: 'FDA',
           show: !hideFda && !!highestFdaLevel,
-          value: <HighestLevelEvidence type="Fda" level={highestFdaLevel} />,
+          value: (
+            <HighestLevelEvidence
+              type="Fda"
+              level={highestFdaLevel ?? undefined}
+            />
+          ),
         },
       ],
     ],

--- a/src/main/webapp/app/shared/tiles/tile-utils.tsx
+++ b/src/main/webapp/app/shared/tiles/tile-utils.tsx
@@ -98,6 +98,7 @@ function MutationEffectIcon({
     </span>
   );
 }
+
 export function createHighestLevelOfEvidenceTileProps(
   variantAnnotation: VariantAnnotation | GeneNumber,
   includeTitle: boolean,
@@ -105,11 +106,14 @@ export function createHighestLevelOfEvidenceTileProps(
 ): AlterationTileProps {
   const {
     highestDiagnosticImplicationLevel,
-    highestFdaLevel,
     highestPrognosticImplicationLevel,
     highestResistanceLevel,
     highestSensitiveLevel,
   } = variantAnnotation;
+  const highestFdaLevel =
+    'highestFdaLevel' in variantAnnotation
+      ? variantAnnotation.highestFdaLevel
+      : undefined;
   return {
     title: includeTitle ? 'Highest Level of Evidence' : undefined,
     items: [

--- a/src/main/webapp/app/shared/utils/LevelUtils.ts
+++ b/src/main/webapp/app/shared/utils/LevelUtils.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_ANNOTATION } from 'app/config/constants';
+import {
+  LevelInfo,
+  SomaticVariantAnnotation,
+} from 'app/shared/api/generated/OncoKbPrivateAPI';
+
+export function getHighestSensitiveLevel(
+  level: LevelInfo['highestSensitiveLevel']
+): SomaticVariantAnnotation['highestSensitiveLevel'] {
+  switch (level) {
+    case 'LEVEL_1':
+    case 'LEVEL_2':
+    case 'LEVEL_3A':
+    case 'LEVEL_3B':
+    case 'LEVEL_4':
+      return level;
+    default:
+      return DEFAULT_ANNOTATION.highestSensitiveLevel;
+  }
+}
+
+export function getHighestDiagnosticImplicationLevel(
+  level: LevelInfo['highestDiagnosticLevel']
+): SomaticVariantAnnotation['highestDiagnosticImplicationLevel'] {
+  switch (level) {
+    case 'LEVEL_Dx1':
+    case 'LEVEL_Dx2':
+    case 'LEVEL_Dx3':
+      return level;
+    default:
+      return DEFAULT_ANNOTATION.highestDiagnosticImplicationLevel;
+  }
+}
+
+export function getHighestPrognosticImplicationLevel(
+  level: LevelInfo['highestPrognosticLevel']
+): SomaticVariantAnnotation['highestPrognosticImplicationLevel'] {
+  switch (level) {
+    case 'LEVEL_Px1':
+    case 'LEVEL_Px2':
+    case 'LEVEL_Px3':
+      return level;
+    default:
+      return DEFAULT_ANNOTATION.highestPrognosticImplicationLevel;
+  }
+}
+
+export function getHighestResistanceLevel(
+  level: LevelInfo['highestResistanceLevel']
+): SomaticVariantAnnotation['highestResistanceLevel'] {
+  switch (level) {
+    case 'LEVEL_R1':
+    case 'LEVEL_R2':
+      return level;
+    default:
+      return DEFAULT_ANNOTATION.highestResistanceLevel;
+  }
+}
+
+export function getHighestFdaLevel(
+  level: LevelInfo['highestFDALevel']
+): SomaticVariantAnnotation['highestFdaLevel'] {
+  switch (level) {
+    case 'LEVEL_Fda1':
+    case 'LEVEL_Fda2':
+    case 'LEVEL_Fda3':
+      return level;
+    default:
+      return DEFAULT_ANNOTATION.highestFdaLevel;
+  }
+}

--- a/src/main/webapp/app/shared/utils/ReactTableUtils.ts
+++ b/src/main/webapp/app/shared/utils/ReactTableUtils.ts
@@ -10,7 +10,7 @@ import {
   getAllTumorTypesName,
   levelOfEvidence2Level,
 } from 'app/shared/utils/Utils';
-import { TumorType } from '../api/generated/OncoKbPrivateAPI';
+import { TumorType, TumorTypeEntity } from '../api/generated/OncoKbPrivateAPI';
 import { isNumber } from 'app/shared/utils/LodashUtils';
 
 export function sortByArrayIndexAsc(aIndex: number, bIndex: number) {
@@ -206,6 +206,9 @@ export function mutationEffectSortMethod(
   );
 }
 
-export function tumorTypeSortMethod(a: TumorType[], b: TumorType[]) {
+export function tumorTypeSortMethod(
+  a: TumorTypeEntity[],
+  b: TumorTypeEntity[]
+) {
   return getAllTumorTypesName(a).localeCompare(getAllTumorTypesName(b));
 }

--- a/src/main/webapp/app/shared/utils/Utils.tsx
+++ b/src/main/webapp/app/shared/utils/Utils.tsx
@@ -45,6 +45,7 @@ import {
   Tag,
   Treatment,
   TumorType,
+  TumorTypeEntity,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import InfoIcon from 'app/shared/icons/InfoIcon';
 import { LevelOfEvidencePageLink } from 'app/shared/links/LevelOfEvidencePageLink';
@@ -96,7 +97,7 @@ export function shortenTextByCharacters(text: string, cutoff: number) {
 }
 
 export function getCancerTypeNameFromOncoTreeType(
-  oncoTreeType: TumorType
+  oncoTreeType: TumorTypeEntity
 ): string {
   return oncoTreeType.subtype || oncoTreeType.mainType || 'NA';
 }
@@ -124,8 +125,8 @@ export function formatEnumLabel(value?: string | null): string {
 }
 
 export function getCancerTypesNameFromOncoTreeType(
-  cancerTypes: TumorType[],
-  excludedCancerTypes?: TumorType[]
+  cancerTypes: TumorTypeEntity[],
+  excludedCancerTypes?: TumorTypeEntity[]
 ): string {
   return getCancerTypesName(
     cancerTypes.map(cancerType =>
@@ -189,7 +190,7 @@ export function getAllAlterationsName(alterations: Alteration[]) {
     : '';
 }
 
-export function getAllTumorTypesName(tumorTypes: TumorType[]) {
+export function getAllTumorTypesName(tumorTypes: TumorTypeEntity[]) {
   return tumorTypes
     ? tumorTypes.map(getCancerTypeNameFromOncoTreeType).sort().join(', ')
     : '';

--- a/src/main/webapp/app/store/AnnotationStore.ts
+++ b/src/main/webapp/app/store/AnnotationStore.ts
@@ -35,6 +35,7 @@ import {
   Tag,
   SomaticVariantAnnotation,
   TumorType,
+  TumorTypeEntity,
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import { BarChartDatum } from 'app/components/barChart/BarChart';
 import {
@@ -629,7 +630,7 @@ export class AnnotationStore {
     default: [],
   });
 
-  readonly allCancerTypes = remoteData<TumorType[]>({
+  readonly allCancerTypes = remoteData<TumorTypeEntity[]>({
     await: () => [],
     async invoke() {
       const result = await privateClient.utilsTumorTypesGetUsingGET({});


### PR DESCRIPTION
closes https://github.com/oncokb/oncokb-pipeline/issues/1050

## Task Notes

### `Highestsensitivelevel` and other `Highest*Level` are nullable, but swagger doesn't generate null.

For this task I modified `scripts/generate-api.js` to look for `(nullable)` in the description since we need to have upgrade our swagger to represent nulls

### There is a TumorType and TumorTypeEntity model that the API can return. We should consolidate the core to just return only the TumorType (apiModel) instead of TumorTypeEntity (database model).

I had to give up on this task. There are a few database models being returned in the API response. I think we just need to wait for the rewrite. 
