### PR TITLE
Allow PREMIUM_USER to access all genomic indicators

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/TokenSecurityConfiguration.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/TokenSecurityConfiguration.java
@@ -141,6 +141,8 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/v1/utils/allAnnotatedVariants.txt").hasAnyAuthority(AuthoritiesConstants.PREMIUM_USER, AuthoritiesConstants.ADMIN, AuthoritiesConstants.DATA_DOWNLOAD)
             .antMatchers("/api/v1/utils/allVariantsOfUnknownSignificance").hasAnyAuthority(AuthoritiesConstants.PREMIUM_USER, AuthoritiesConstants.ADMIN)
             .antMatchers("/api/v1/utils/allVariantsOfUnknownSignificance.txt").hasAnyAuthority(AuthoritiesConstants.PREMIUM_USER, AuthoritiesConstants.ADMIN)
+            .antMatchers("/api/v1/utils/allGenomicIndicators").hasAnyAuthority(AuthoritiesConstants.PREMIUM_USER, AuthoritiesConstants.ADMIN)
+            .antMatchers("/api/v1/utils/allGenomicIndicators.txt").hasAnyAuthority(AuthoritiesConstants.PREMIUM_USER, AuthoritiesConstants.ADMIN, AuthoritiesConstants.DATA_DOWNLOAD)
 
             .antMatchers("/api/v1/**").hasAnyAuthority(AuthoritiesConstants.ADMIN)
 


### PR DESCRIPTION
I'll update gitbook after I release this change.