### PR TITLE
Support HGNC :: fusion nomenclature

### DIFF
--- a/src/main/webapp/app/components/oncokbSearch/SearchInfoIcon.tsx
+++ b/src/main/webapp/app/components/oncokbSearch/SearchInfoIcon.tsx
@@ -73,6 +73,16 @@ export default class SearchInfoIcon extends React.Component<
               ],
             },
             {
+              key: 'fusion',
+              content: [
+                { key: 'fusion-0', content: 'Fusion' },
+                {
+                  key: 'fusion-1',
+                  content: this.getQueryLink('BCR::ABL1 Fusion'),
+                },
+              ],
+            },
+            {
               key: 'cancerType',
               content: [
                 { key: 'cancerType-0', content: 'Cancer Type' },

--- a/src/main/webapp/app/config/constants.tsx
+++ b/src/main/webapp/app/config/constants.tsx
@@ -560,7 +560,7 @@ export const DEFAULT_PROTEIN_CHANGE_VALIDATION: ProteinChangeValidation = {
 };
 
 export const DEFAULT_ANNOTATION: SomaticVariantAnnotation = {
-  alterationValidationError: null,
+  errors: [],
   alternativeOncoKbVariant: {
     gene: '',
     inputVariant: '',
@@ -818,6 +818,10 @@ export const PATHOGENIC_VARIANTS = 'Pathogenic Variants';
 export const AMPLIFICATION = 'Amplification';
 export const DELETION = 'Deletion';
 export const FUSIONS = 'Fusions';
+// HGNC separates fusion gene partners with "::". A single hyphen is still accepted
+// by the API for backwards compatibility, but is ambiguous when a partner symbol
+// itself contains a hyphen (e.g. NKX3-1, HLA-A).
+export const FUSION_SEPARATOR = '::';
 export const TRUNCATING_MUTATIONS = 'Truncating Mutations';
 export const OTHER_BIOMARKERS = 'Other Biomarkers';
 export const GAIN_OF_FUNCTION_MUTATIONS = 'Gain-of-function Mutations';

--- a/src/main/webapp/app/pages/annotationPage/SomaticGermlineCancerTypePage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/SomaticGermlineCancerTypePage.tsx
@@ -25,7 +25,13 @@ import {
   parseAlterationPagePath,
   AlterationPageLink,
 } from 'app/shared/utils/UrlUtils';
-import { computed, reaction, action, observable } from 'mobx';
+import {
+  computed,
+  reaction,
+  action,
+  observable,
+  IReactionDisposer,
+} from 'mobx';
 import { GENETIC_TYPE } from 'app/components/geneticTypeTabs/GeneticTypeTabs';
 import { observer, inject } from 'mobx-react';
 import classnames from 'classnames';
@@ -115,6 +121,8 @@ export class SomaticGermlineCancerTypePage extends React.Component<
   // open it by default without overriding an explicit choice afterwards.
   @observable additionalGeneInfoToggledTo?: boolean;
 
+  readonly reactions: IReactionDisposer[] = [];
+
   constructor(props: SomaticGermlineCancerTypePageProps) {
     super(props);
     const alterationQuery = decodeSlash(props.match.params.alteration);
@@ -122,58 +130,63 @@ export class SomaticGermlineCancerTypePage extends React.Component<
       props.location.search
     ) as SearchParams;
 
-    reaction(
-      () => [this.props.routing.location.pathname],
-      () => {
-        this.store.hugoSymbolQuery = this.props.match.params.hugoSymbol;
-        this.store.alterationQuery =
-          decodeSlash(this.props.match.params.alteration) ?? '';
-        this.store.tumorTypeQuery =
-          decodeSlash(this.props.match.params.tumorType) ?? '';
-      }
-    );
-    reaction(
-      () => [this.geneticType],
-      ([geneticType]) => {
-        if (props.match.params) {
-          this.store = new AnnotationStore({
-            type: alterationQuery
-              ? AnnotationType.PROTEIN_CHANGE
-              : AnnotationType.GENE,
-            hugoSymbolQuery: props.match.params.hugoSymbol,
-            alterationQuery,
-            germline: geneticType === GENETIC_TYPE.GERMLINE,
-            tumorTypeQuery: props.match.params.tumorType
-              ? decodeSlash(props.match.params.tumorType)
-              : props.match.params.tumorType,
-            referenceGenomeQuery: searchParams.refGenome,
-          });
-          if (this.store.cancerTypeName) {
-            this.showMutationEffect = false;
-          }
+    this.reactions.push(
+      reaction(
+        () => [this.props.routing.location.pathname],
+        () => {
+          this.store.hugoSymbolQuery = this.props.match.params.hugoSymbol;
+          this.store.alterationQuery =
+            decodeSlash(this.props.match.params.alteration) ?? '';
+          this.store.tumorTypeQuery =
+            decodeSlash(this.props.match.params.tumorType) ?? '';
         }
-      },
-      true
-    );
-    reaction(
-      () => [props.location.hash],
-      ([hash]) => {
-        const queryStrings = QueryString.parse(
-          hash
-        ) as AlterationPageHashQueries;
-        if (queryStrings.tab) {
-          if (queryStrings.tab === ANNOTATION_PAGE_TAB_KEYS.FDA) {
-            this.props.appStore.inFdaRecognizedContent = true;
+      ),
+      reaction(
+        () => [this.geneticType],
+        ([geneticType]) => {
+          if (props.match.params) {
+            this.store = new AnnotationStore({
+              type: alterationQuery
+                ? AnnotationType.PROTEIN_CHANGE
+                : AnnotationType.GENE,
+              hugoSymbolQuery: props.match.params.hugoSymbol,
+              alterationQuery,
+              germline: geneticType === GENETIC_TYPE.GERMLINE,
+              tumorTypeQuery: props.match.params.tumorType
+                ? decodeSlash(props.match.params.tumorType)
+                : props.match.params.tumorType,
+              referenceGenomeQuery: searchParams.refGenome,
+            });
+            if (this.store.cancerTypeName) {
+              this.showMutationEffect = false;
+            }
           }
-        }
-      },
-      true
+        },
+        true
+      ),
+      reaction(
+        () => [props.location.hash],
+        ([hash]) => {
+          const queryStrings = QueryString.parse(
+            hash
+          ) as AlterationPageHashQueries;
+          if (queryStrings.tab) {
+            if (queryStrings.tab === ANNOTATION_PAGE_TAB_KEYS.FDA) {
+              this.props.appStore.inFdaRecognizedContent = true;
+            }
+          }
+        },
+        true
+      ),
+      reaction(
+        () => this.canonicalFusionAlteration,
+        this.redirectToCanonicalPage
+      )
     );
+  }
 
-    reaction(
-      () => this.canonicalFusionAlteration,
-      this.redirectToCanonicalPage
-    );
+  componentWillUnmount() {
+    this.reactions.forEach(componentReaction => componentReaction());
   }
 
   @computed

--- a/src/main/webapp/app/pages/annotationPage/SomaticGermlineCancerTypePage.tsx
+++ b/src/main/webapp/app/pages/annotationPage/SomaticGermlineCancerTypePage.tsx
@@ -18,6 +18,7 @@ import {
   articles2Citations,
   isCategoricalAlteration,
   isPositionalAlteration,
+  getCanonicalFusionAlteration,
 } from 'app/shared/utils/Utils';
 import {
   getAlterationPageLink,
@@ -168,6 +169,39 @@ export class SomaticGermlineCancerTypePage extends React.Component<
       },
       true
     );
+
+    reaction(
+      () => this.canonicalFusionAlteration,
+      this.redirectToCanonicalPage
+    );
+  }
+
+  @computed
+  get canonicalFusionAlteration() {
+    if (!this.annotationData.isComplete) {
+      return undefined;
+    }
+    return getCanonicalFusionAlteration(
+      this.store.alterationQuery,
+      this.annotationData.result.query.alteration
+    );
+  }
+
+  @action.bound
+  redirectToCanonicalPage(canonicalAlteration?: string) {
+    if (!canonicalAlteration) {
+      return;
+    }
+    this.props.routing.history.replace({
+      pathname: getAlterationPageLink({
+        hugoSymbol: this.store.hugoSymbol,
+        alteration: canonicalAlteration,
+        cancerType: this.store.cancerTypeName,
+        germline: this.store.germline,
+      }),
+      search: this.props.location.search,
+      hash: this.props.location.hash,
+    });
   }
 
   @action.bound

--- a/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticGermlineAlterationPage.tsx
+++ b/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticGermlineAlterationPage.tsx
@@ -27,7 +27,13 @@ import {
   parseAlterationPagePath,
   AlterationPageLink,
 } from 'app/shared/utils/UrlUtils';
-import { computed, reaction, action, observable } from 'mobx';
+import {
+  computed,
+  reaction,
+  action,
+  observable,
+  IReactionDisposer,
+} from 'mobx';
 import { GENETIC_TYPE } from 'app/components/geneticTypeTabs/GeneticTypeTabs';
 import { observer, inject } from 'mobx-react';
 import styles from './SomaticGermlineAlterationPage.module.scss';
@@ -117,6 +123,8 @@ export class SomaticGermlineAlterationPage extends React.Component<
   // open it by default without overriding an explicit choice afterwards.
   @observable additionalGeneInfoToggledTo?: boolean;
 
+  readonly reactions: IReactionDisposer[] = [];
+
   constructor(props: SomaticGermlineAlterationPageProps) {
     super(props);
     const alterationQuery = decodeSlash(props.match.params.alteration);
@@ -136,26 +144,31 @@ export class SomaticGermlineAlterationPage extends React.Component<
       this.showMutationEffect = false;
     }
 
-    reaction(
-      () => [props.location.hash],
-      ([hash]) => {
-        const queryStrings = QueryString.parse(
-          hash
-        ) as AlterationPageHashQueries;
-        if (queryStrings.tab) {
-          this.selectedTab = queryStrings.tab;
-          if (queryStrings.tab === ANNOTATION_PAGE_TAB_KEYS.FDA) {
-            this.props.appStore.inFdaRecognizedContent = true;
+    this.reactions.push(
+      reaction(
+        () => [props.location.hash],
+        ([hash]) => {
+          const queryStrings = QueryString.parse(
+            hash
+          ) as AlterationPageHashQueries;
+          if (queryStrings.tab) {
+            this.selectedTab = queryStrings.tab;
+            if (queryStrings.tab === ANNOTATION_PAGE_TAB_KEYS.FDA) {
+              this.props.appStore.inFdaRecognizedContent = true;
+            }
           }
-        }
-      },
-      true
+        },
+        true
+      ),
+      reaction(
+        () => this.canonicalFusionAlteration,
+        this.redirectToCanonicalPage
+      )
     );
+  }
 
-    reaction(
-      () => this.canonicalFusionAlteration,
-      this.redirectToCanonicalPage
-    );
+  componentWillUnmount() {
+    this.reactions.forEach(componentReaction => componentReaction());
   }
 
   @computed

--- a/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticGermlineAlterationPage.tsx
+++ b/src/main/webapp/app/pages/somaticGermlineAlterationPage/SomaticGermlineAlterationPage.tsx
@@ -20,6 +20,7 @@ import {
   isPositionalAlteration,
   getCategoricalAlterationDescription,
   getImplicationsFromTags,
+  getCanonicalFusionAlteration,
 } from 'app/shared/utils/Utils';
 import {
   getAlterationPageLink,
@@ -150,6 +151,39 @@ export class SomaticGermlineAlterationPage extends React.Component<
       },
       true
     );
+
+    reaction(
+      () => this.canonicalFusionAlteration,
+      this.redirectToCanonicalPage
+    );
+  }
+
+  @computed
+  get canonicalFusionAlteration() {
+    if (!this.annotationData.isComplete) {
+      return undefined;
+    }
+    return getCanonicalFusionAlteration(
+      this.store.alterationQuery,
+      this.annotationData.result.query.alteration
+    );
+  }
+
+  @action.bound
+  redirectToCanonicalPage(canonicalAlteration?: string) {
+    if (!canonicalAlteration) {
+      return;
+    }
+    this.props.routing.history.replace({
+      pathname: getAlterationPageLink({
+        hugoSymbol: this.store.hugoSymbol,
+        alteration: canonicalAlteration,
+        cancerType: this.store.cancerTypeName,
+        germline: this.store.germline,
+      }),
+      search: this.props.location.search,
+      hash: this.props.location.hash,
+    });
   }
 
   @action.bound

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI-docs.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "These endpoints are for private use only.",
-    "version": "v1.6.0",
+    "version": "v1.7.0",
     "title": "OncoKB Private APIs",
     "contact": {
       "name": "OncoKB",
@@ -327,6 +327,29 @@
             "description": "OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "inheritanceMechanisms",
+            "in": "query",
+            "description": "List of inheritance mechanisms used to filter the returned genomic indicators. The special value CARRIER is matched against the genomic indicator name rather than the inheritance mechanism. Example: AUTOSOMAL_DOMINANT,CARRIER",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "AUTOSOMAL_DOMINANT",
+                "AUTOSOMAL_RECESSIVE",
+                "X_LINKED_RECESSIVE",
+                "CARRIER"
+              ]
+            },
+            "collectionFormat": "multi",
+            "enum": [
+              "AUTOSOMAL_DOMINANT",
+              "AUTOSOMAL_RECESSIVE",
+              "X_LINKED_RECESSIVE",
+              "CARRIER"
+            ]
           }
         ],
         "responses": {
@@ -3379,6 +3402,27 @@
         }
       }
     },
+    "ValidationError": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "example": "BRAF A600E: The reference amino acid at position 600 is V instead of A on the OncoKB canonical transcript.",
+          "description": "The same reason in words, naming what was queried and what OncoKB has instead."
+        },
+        "type": {
+          "type": "string",
+          "description": "What is wrong with the query.",
+          "enum": [
+            "REFERENCE_ALLELE_MISMATCH",
+            "POSITION_OUT_OF_RANGE",
+            "REVERSED_POSITION_RANGE",
+            "MALFORMED_ALTERATION",
+            "AMBIGUOUS_FUSION_SEPARATOR"
+          ]
+        }
+      }
+    },
     "ActionableGene": {
       "type": "object",
       "properties": {
@@ -3522,6 +3566,18 @@
         },
         "id": {
           "type": "string"
+        },
+        "inheritanceMechanisms": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AUTOSOMAL_DOMINANT",
+              "AUTOSOMAL_RECESSIVE",
+              "X_LINKED_RECESSIVE",
+              "CARRIER"
+            ]
+          }
         },
         "referenceGenome": {
           "type": "string",
@@ -3723,26 +3779,6 @@
         },
         "tumorType": {
           "type": "string"
-        }
-      }
-    },
-    "AlterationValidationError": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "example": "BRAF A600E: The reference amino acid at position 600 is V instead of A on the OncoKB canonical transcript.",
-          "description": "The same reason in words, naming the queried alteration and what the OncoKB canonical sequence has instead."
-        },
-        "type": {
-          "type": "string",
-          "description": "The reason the alteration was rejected.",
-          "enum": [
-            "REFERENCE_ALLELE_MISMATCH",
-            "POSITION_OUT_OF_RANGE",
-            "REVERSED_POSITION_RANGE",
-            "MALFORMED_ALTERATION"
-          ]
         }
       }
     },
@@ -3982,10 +4018,6 @@
           "example": false,
           "description": "Indicates whether the alternate allele has been curated. See SOP Protocol 9.1"
         },
-        "alterationValidationError": {
-          "description": "(Nullable) Why the queried alteration was rejected as impossible against the OncoKB canonical sequence, leaving the query annotated at the gene level only. Carries both the reason to branch on and the same reason in words. Null whenever the variant itself was annotated. See docs/alteration-validation-errors.md",
-          "$ref": "#/definitions/AlterationValidationError"
-        },
         "dataVersion": {
           "type": "string",
           "example": "v4.25",
@@ -4001,6 +4033,13 @@
         "diagnosticSummary": {
           "type": "string",
           "description": "Diagnostic summary. Defaulted to \"\""
+        },
+        "errors": {
+          "type": "array",
+          "description": "Everything OncoKB found wrong with the query, each carrying both a reason to branch on and the same reason in words. Empty whenever there is nothing wrong, and never null. An error may mean the variant was left unannotated - a queried alteration that cannot exist against the OncoKB canonical sequence is annotated at the gene level only. See docs/validation-errors.md",
+          "items": {
+            "$ref": "#/definitions/ValidationError"
+          }
         },
         "exon": {
           "type": "string",

--- a/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbAPI.ts
@@ -219,6 +219,12 @@ export type AnnotateStructuralVariantQuery = {
         'tumorType': string
 
 };
+export type ValidationError = {
+    'message': string
+
+        'type': "REFERENCE_ALLELE_MISMATCH" | "POSITION_OUT_OF_RANGE" | "REVERSED_POSITION_RANGE" | "MALFORMED_ALTERATION" | "AMBIGUOUS_FUSION_SEPARATOR"
+
+};
 export type ActionableGene = {
     'abstracts': string
 
@@ -279,6 +285,8 @@ export type AnnotateMutationByHGVScQuery = {
         'hgvsc': string
 
         'id': string
+
+        'inheritanceMechanisms': Array < "AUTOSOMAL_DOMINANT" | "AUTOSOMAL_RECESSIVE" | "X_LINKED_RECESSIVE" | "CARRIER" >
 
         'referenceGenome': "GRCh37" | "GRCh38"
 
@@ -355,12 +363,6 @@ export type AnnotateCopyNumberAlterationQuery = {
         'referenceGenome': "GRCh37" | "GRCh38"
 
         'tumorType': string
-
-};
-export type AlterationValidationError = {
-    'message': string
-
-        'type': "REFERENCE_ALLELE_MISMATCH" | "POSITION_OUT_OF_RANGE" | "REVERSED_POSITION_RANGE" | "MALFORMED_ALTERATION"
 
 };
 export type AllGenomicIndicator = {
@@ -490,13 +492,13 @@ export type AnnotatedVariant = {
 export type SomaticIndicatorQueryResp = {
     'alleleExist': boolean
 
-        'alterationValidationError': AlterationValidationError
-
         'dataVersion': string
 
         'diagnosticImplications': Array < Implication >
 
         'diagnosticSummary': string
+
+        'errors': Array < ValidationError >
 
         'exon': string
 
@@ -1367,6 +1369,7 @@ export default class OncoKbAPI {
         'hgvsc': string,
         'referenceGenome' ? : string,
         'tumorType' ? : string,
+        'inheritanceMechanisms' ? : "AUTOSOMAL_DOMINANT" | "AUTOSOMAL_RECESSIVE" | "X_LINKED_RECESSIVE" | "CARRIER",
         $queryParameters ? : any
     }): string {
         let queryParameters: any = {};
@@ -1381,6 +1384,10 @@ export default class OncoKbAPI {
 
         if (parameters['tumorType'] !== undefined) {
             queryParameters['tumorType'] = parameters['tumorType'];
+        }
+
+        if (parameters['inheritanceMechanisms'] !== undefined) {
+            queryParameters['inheritanceMechanisms'] = parameters['inheritanceMechanisms'];
         }
 
         if (parameters.$queryParameters) {
@@ -1400,11 +1407,13 @@ export default class OncoKbAPI {
      * @param {string} hgvsc - HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T
      * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
      * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     * @param {array} inheritanceMechanisms - List of inheritance mechanisms used to filter the returned genomic indicators. The special value CARRIER is matched against the genomic indicator name rather than the inheritance mechanism. Example: AUTOSOMAL_DOMINANT,CARRIER
      */
     annotateMutationsByHGVScGetUsingGET_1WithHttpInfo(parameters: {
         'hgvsc': string,
         'referenceGenome' ? : string,
         'tumorType' ? : string,
+        'inheritanceMechanisms' ? : "AUTOSOMAL_DOMINANT" | "AUTOSOMAL_RECESSIVE" | "X_LINKED_RECESSIVE" | "CARRIER",
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < request.Response > {
@@ -1437,6 +1446,10 @@ export default class OncoKbAPI {
                 queryParameters['tumorType'] = parameters['tumorType'];
             }
 
+            if (parameters['inheritanceMechanisms'] !== undefined) {
+                queryParameters['inheritanceMechanisms'] = parameters['inheritanceMechanisms'];
+            }
+
             if (parameters.$queryParameters) {
                 Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
                     var parameter = parameters.$queryParameters[parameterName];
@@ -1456,11 +1469,13 @@ export default class OncoKbAPI {
      * @param {string} hgvsc - HGVS cDNA format following HGVS nomenclature. Example: EGFR:c.2369C>T
      * @param {string} referenceGenome - Reference genome, either GRCh37 or GRCh38. The default is GRCh37
      * @param {string} tumorType - OncoTree(http://oncotree.info) tumor type name. The field supports OncoTree Code, OncoTree Name and OncoTree Main type. Example: Melanoma
+     * @param {array} inheritanceMechanisms - List of inheritance mechanisms used to filter the returned genomic indicators. The special value CARRIER is matched against the genomic indicator name rather than the inheritance mechanism. Example: AUTOSOMAL_DOMINANT,CARRIER
      */
     annotateMutationsByHGVScGetUsingGET_1(parameters: {
         'hgvsc': string,
         'referenceGenome' ? : string,
         'tumorType' ? : string,
+        'inheritanceMechanisms' ? : "AUTOSOMAL_DOMINANT" | "AUTOSOMAL_RECESSIVE" | "X_LINKED_RECESSIVE" | "CARRIER",
         $queryParameters ? : any,
         $domain ? : string
     }): Promise < GermlineIndicatorQueryResp > {

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI-docs.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "OncoKB, a comprehensive and curated precision oncology knowledge base, offers oncologists detailed, evidence-based information about individual somatic mutations and structural alterations present in patient tumors with the goal of supporting optimal treatment decisions.",
-    "version": "v1.6.0",
+    "version": "v1.7.0",
     "title": "OncoKB APIs",
     "contact": {
       "name": "OncoKB",
@@ -1023,6 +1023,65 @@
               "type": "array",
               "items": {
                 "type": "string"
+              }
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Error, error message will be given.",
+            "schema": {
+              "$ref": "#/definitions/ApiHttpError"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/utils/genomicIndicators": {
+      "post": {
+        "tags": [
+          "Utils"
+        ],
+        "summary": "utilsGenomicIndicatorsPost",
+        "description": "Get the germline genomic indicators for a list of genes and variants.",
+        "operationId": "utilsGenomicIndicatorsPostUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of queries. Each query specifies a hugoSymbol, variant, and optional inheritanceMechanisms filter.",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GenomicIndicatorQuery"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GenomicIndicatorQueryResp"
               }
             }
           },
@@ -2834,6 +2893,27 @@
         }
       }
     },
+    "ValidationError": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "example": "BRAF A600E: The reference amino acid at position 600 is V instead of A on the OncoKB canonical transcript.",
+          "description": "The same reason in words, naming what was queried and what OncoKB has instead."
+        },
+        "type": {
+          "type": "string",
+          "description": "What is wrong with the query.",
+          "enum": [
+            "REFERENCE_ALLELE_MISMATCH",
+            "POSITION_OUT_OF_RANGE",
+            "REVERSED_POSITION_RANGE",
+            "MALFORMED_ALTERATION",
+            "AMBIGUOUS_FUSION_SEPARATOR"
+          ]
+        }
+      }
+    },
     "ProteinChangeValidation": {
       "type": "object",
       "properties": {
@@ -2847,7 +2927,8 @@
             "NORMALIZED_DELETED_SEQUENCE",
             "NO_PROTEIN_SEQUENCE",
             "TRANSCRIPT_SERVICE_DISABLED",
-            "TRANSCRIPT_SERVICE_UNAVAILABLE"
+            "TRANSCRIPT_SERVICE_UNAVAILABLE",
+            "AMBIGUOUS_FUSION_SEPARATOR"
           ]
         },
         "normalizedProteinChange": {
@@ -2862,6 +2943,33 @@
           ]
         }
       }
+    },
+    "GenomicIndicatorQuery": {
+      "type": "object",
+      "properties": {
+        "hugoSymbol": {
+          "type": "string",
+          "description": "The gene symbol used in Human Genome Organisation."
+        },
+        "inheritanceMechanisms": {
+          "type": "array",
+          "description": "List of inheritance mechanisms used to filter the returned genomic indicators. The special value CARRIER is matched against the genomic indicator name rather than the inheritance mechanism. Example: AUTOSOMAL_DOMINANT,CARRIER",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AUTOSOMAL_DOMINANT",
+              "AUTOSOMAL_RECESSIVE",
+              "X_LINKED_RECESSIVE",
+              "CARRIER"
+            ]
+          }
+        },
+        "variant": {
+          "type": "string",
+          "description": "Variant name"
+        }
+      },
+      "description": "Query for retrieving the germline genomic indicators associated with a specific gene and variant"
     },
     "MatchVariantRequest": {
       "type": "object",
@@ -3009,26 +3117,6 @@
         },
         "variant": {
           "$ref": "#/definitions/Alteration"
-        }
-      }
-    },
-    "AlterationValidationError": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "example": "BRAF A600E: The reference amino acid at position 600 is V instead of A on the OncoKB canonical transcript.",
-          "description": "The same reason in words, naming the queried alteration and what the OncoKB canonical sequence has instead."
-        },
-        "type": {
-          "type": "string",
-          "description": "The reason the alteration was rejected.",
-          "enum": [
-            "REFERENCE_ALLELE_MISMATCH",
-            "POSITION_OUT_OF_RANGE",
-            "REVERSED_POSITION_RANGE",
-            "MALFORMED_ALTERATION"
-          ]
         }
       }
     },
@@ -4115,6 +4203,23 @@
         }
       }
     },
+    "GenomicIndicatorQueryResp": {
+      "type": "object",
+      "properties": {
+        "genomicIndicators": {
+          "type": "array",
+          "description": "The germline genomic indicators associated with the query",
+          "items": {
+            "$ref": "#/definitions/GenomicIndicator"
+          }
+        },
+        "query": {
+          "description": "The query the genomic indicators were retrieved for",
+          "$ref": "#/definitions/GenomicIndicatorQuery"
+        }
+      },
+      "description": "The genomic indicators associated with a queried gene and variant"
+    },
     "Tag": {
       "type": "object",
       "properties": {
@@ -4206,10 +4311,6 @@
         "alteration": {
           "$ref": "#/definitions/Alteration"
         },
-        "alterationValidationError": {
-          "description": "(Nullable) Why the queried alteration was rejected as impossible against the OncoKB canonical sequence, leaving the query annotated at the gene level only. Carries both the reason to branch on and the same reason in words. Null whenever the variant itself was annotated. See docs/alteration-validation-errors.md",
-          "$ref": "#/definitions/AlterationValidationError"
-        },
         "alternativeOncoKbVariant": {
           "$ref": "#/definitions/AlternativeOncoKbVariant"
         },
@@ -4231,6 +4332,13 @@
         "diagnosticSummary": {
           "type": "string",
           "description": "Diagnostic summary. Defaulted to \"\""
+        },
+        "errors": {
+          "type": "array",
+          "description": "Everything OncoKB found wrong with the query, each carrying both a reason to branch on and the same reason in words. Empty whenever there is nothing wrong, and never null. An error may mean the variant was left unannotated - a queried alteration that cannot exist against the OncoKB canonical sequence is annotated at the gene level only. See docs/validation-errors.md",
+          "items": {
+            "$ref": "#/definitions/ValidationError"
+          }
         },
         "exon": {
           "type": "string",

--- a/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
+++ b/src/main/webapp/app/shared/api/generated/OncoKbPrivateAPI.ts
@@ -253,14 +253,28 @@ export type MatchVariantResult = {
         'result': Array < MatchVariant >
 
 };
+export type ValidationError = {
+    'message': string
+
+        'type': "REFERENCE_ALLELE_MISMATCH" | "POSITION_OUT_OF_RANGE" | "REVERSED_POSITION_RANGE" | "MALFORMED_ALTERATION" | "AMBIGUOUS_FUSION_SEPARATOR"
+
+};
 export type ProteinChangeValidation = {
     'message': string
 
-        'messageType': "INVALID_PROTEIN_CHANGE" | "NORMALIZED_DELETED_SEQUENCE" | "NO_PROTEIN_SEQUENCE" | "TRANSCRIPT_SERVICE_DISABLED" | "TRANSCRIPT_SERVICE_UNAVAILABLE"
+        'messageType': "INVALID_PROTEIN_CHANGE" | "NORMALIZED_DELETED_SEQUENCE" | "NO_PROTEIN_SEQUENCE" | "TRANSCRIPT_SERVICE_DISABLED" | "TRANSCRIPT_SERVICE_UNAVAILABLE" | "AMBIGUOUS_FUSION_SEPARATOR"
 
         'normalizedProteinChange': string
 
         'status': "NORMALIZED" | "INVALID" | "UNCHECKED"
+
+};
+export type GenomicIndicatorQuery = {
+    'hugoSymbol': string
+
+        'inheritanceMechanisms': Array < "AUTOSOMAL_DOMINANT" | "AUTOSOMAL_RECESSIVE" | "X_LINKED_RECESSIVE" | "CARRIER" >
+
+        'variant': string
 
 };
 export type MatchVariantRequest = {
@@ -329,12 +343,6 @@ export type BiologicalVariant = {
         'penetrance': string
 
         'variant': Alteration
-
-};
-export type AlterationValidationError = {
-    'message': string
-
-        'type': "REFERENCE_ALLELE_MISMATCH" | "POSITION_OUT_OF_RANGE" | "REVERSED_POSITION_RANGE" | "MALFORMED_ALTERATION"
 
 };
 export type GenomicIndicator = {
@@ -769,6 +777,12 @@ export type AnnotateMutationByHGVSgQuery = {
         'tumorType': string
 
 };
+export type GenomicIndicatorQueryResp = {
+    'genomicIndicators': Array < GenomicIndicator >
+
+        'query': GenomicIndicatorQuery
+
+};
 export type Tag = {
     'description': string
 
@@ -808,9 +822,7 @@ export type SomaticVariantAnnotation = {
 
         'alteration': Alteration
 
-        'alterationValidationError': AlterationValidationError | null
-
-        'alternativeOncoKbVariant': AlternativeOncoKbVariant | null
+        'alternativeOncoKbVariant': AlternativeOncoKbVariant
 
         'background': string
 
@@ -819,6 +831,8 @@ export type SomaticVariantAnnotation = {
         'diagnosticImplications': Array < Implication >
 
         'diagnosticSummary': string
+
+        'errors': Array < ValidationError >
 
         'exon': string
 
@@ -2563,6 +2577,83 @@ export default class OncoKbPrivateAPI {
         }): Promise < Array < string >
         > {
             return this.utilFilterHgvsgBasedOnCoveragePostUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
+                return response.body;
+            });
+        };
+    utilsGenomicIndicatorsPostUsingPOSTURL(parameters: {
+        'body': Array < GenomicIndicatorQuery > ,
+        $queryParameters ? : any
+    }): string {
+        let queryParameters: any = {};
+        let path = '/utils/genomicIndicators';
+
+        if (parameters.$queryParameters) {
+            Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                var parameter = parameters.$queryParameters[parameterName];
+                queryParameters[parameterName] = parameter;
+            });
+        }
+        let keys = Object.keys(queryParameters);
+        return this.domain + path + (keys.length > 0 ? '?' + (keys.map(key => key + '=' + encodeURIComponent(queryParameters[key])).join('&')) : '');
+    };
+
+    /**
+     * Get the germline genomic indicators for a list of genes and variants.
+     * @method
+     * @name OncoKbPrivateAPI#utilsGenomicIndicatorsPostUsingPOST
+     * @param {} body - List of queries. Each query specifies a hugoSymbol, variant, and optional inheritanceMechanisms filter.
+     */
+    utilsGenomicIndicatorsPostUsingPOSTWithHttpInfo(parameters: {
+        'body': Array < GenomicIndicatorQuery > ,
+        $queryParameters ? : any,
+        $domain ? : string
+    }): Promise < request.Response > {
+        const domain = parameters.$domain ? parameters.$domain : this.domain;
+        const errorHandlers = this.errorHandlers;
+        const request = this.request;
+        let path = '/utils/genomicIndicators';
+        let body: any;
+        let queryParameters: any = {};
+        let headers: any = {};
+        let form: any = {};
+        return new Promise(function(resolve, reject) {
+            headers['Accept'] = 'application/json';
+            headers['Content-Type'] = 'application/json';
+
+            if (parameters['body'] !== undefined) {
+                body = parameters['body'];
+            }
+
+            if (parameters['body'] === undefined) {
+                reject(new Error('Missing required  parameter: body'));
+                return;
+            }
+
+            if (parameters.$queryParameters) {
+                Object.keys(parameters.$queryParameters).forEach(function(parameterName) {
+                    var parameter = parameters.$queryParameters[parameterName];
+                    queryParameters[parameterName] = parameter;
+                });
+            }
+
+            request('POST', domain + path, body, headers, queryParameters, form, reject, resolve, errorHandlers);
+
+        });
+    };
+
+    /**
+     * Get the germline genomic indicators for a list of genes and variants.
+     * @method
+     * @name OncoKbPrivateAPI#utilsGenomicIndicatorsPostUsingPOST
+     * @param {} body - List of queries. Each query specifies a hugoSymbol, variant, and optional inheritanceMechanisms filter.
+     */
+    utilsGenomicIndicatorsPostUsingPOST(parameters: {
+            'body': Array < GenomicIndicatorQuery > ,
+            $queryParameters ? : any,
+            $domain ? : string
+        }): Promise < Array < GenomicIndicatorQueryResp >
+        > {
+            return this.utilsGenomicIndicatorsPostUsingPOSTWithHttpInfo(parameters).then(function(response: request.Response) {
                 return response.body;
             });
         };

--- a/src/main/webapp/app/shared/utils/FusionUtils.spec.ts
+++ b/src/main/webapp/app/shared/utils/FusionUtils.spec.ts
@@ -1,0 +1,42 @@
+import { getCanonicalFusionAlteration } from 'app/shared/utils/Utils';
+
+describe('getCanonicalFusionAlteration', () => {
+  it('returns the canonical name when the API normalized a hyphen fusion', () => {
+    expect(
+      getCanonicalFusionAlteration('BCR-ABL1 Fusion', 'BCR::ABL1 Fusion')
+    ).toEqual('BCR::ABL1 Fusion');
+  });
+
+  it('returns undefined when the query is already canonical', () => {
+    expect(
+      getCanonicalFusionAlteration('BCR::ABL1 Fusion', 'BCR::ABL1 Fusion')
+    ).toBeUndefined();
+  });
+
+  it('leaves normalized protein changes alone', () => {
+    expect(getCanonicalFusionAlteration('Val600Glu', 'V600E')).toBeUndefined();
+    expect(getCanonicalFusionAlteration('v600e', 'V600E')).toBeUndefined();
+  });
+
+  it('leaves categorical alterations alone', () => {
+    expect(getCanonicalFusionAlteration('Fusions', 'Fusions')).toBeUndefined();
+  });
+
+  // An ambiguous query is rejected by the API rather than normalized, so there is
+  // nothing to redirect to.
+  it('returns undefined when an ambiguous fusion was not normalized', () => {
+    expect(
+      getCanonicalFusionAlteration('NKX3-1-ABL1 Fusion', 'NKX3-1-ABL1 Fusion')
+    ).toBeUndefined();
+  });
+
+  it('handles missing values', () => {
+    expect(
+      getCanonicalFusionAlteration(undefined, 'BCR::ABL1 Fusion')
+    ).toBeUndefined();
+    expect(
+      getCanonicalFusionAlteration('BCR-ABL1 Fusion', undefined)
+    ).toBeUndefined();
+    expect(getCanonicalFusionAlteration('', '')).toBeUndefined();
+  });
+});

--- a/src/main/webapp/app/shared/utils/Utils.tsx
+++ b/src/main/webapp/app/shared/utils/Utils.tsx
@@ -11,6 +11,7 @@ import {
   DELETION,
   EVIDENCE_TYPES,
   FUSIONS,
+  FUSION_SEPARATOR,
   GENERAL_ONCOGENICITY,
   GENERAL_PATHOGENICITY,
   LEVEL_PRIORITY,
@@ -811,6 +812,30 @@ export const isCategoricalAlteration = (alteration: string) => {
       alteration.toLowerCase().startsWith(alt.toLowerCase())
     ).length > 0
   );
+};
+
+/**
+ * The API canonicalizes fusion nomenclature to the HGNC "::" separator, so a page
+ * reached through the legacy single-hyphen form (e.g. "BCR-ABL1 Fusion") should
+ * settle on the canonical URL. Returns the canonical alteration when the annotated
+ * name is a fusion that differs from what was queried, otherwise undefined.
+ */
+export const getCanonicalFusionAlteration = (
+  alterationQuery: string | undefined,
+  annotatedAlteration: string | undefined
+): string | undefined => {
+  if (!alterationQuery || !annotatedAlteration) {
+    return undefined;
+  }
+  if (annotatedAlteration === alterationQuery) {
+    return undefined;
+  }
+  // Restricted to fusions on purpose. The API also normalizes protein changes
+  // (e.g. "Val600Glu" to "V600E"), which the pages render as-is by design.
+  if (!annotatedAlteration.includes(FUSION_SEPARATOR)) {
+    return undefined;
+  }
+  return annotatedAlteration;
 };
 
 export const getCategoricalAlteration = (alteration: string) => {


### PR DESCRIPTION
Frontend support for the HGNC fusion nomenclature change, where fusion gene partners are separated with `::` (e.g. `BCR::ABL1 Fusion`) instead of a single hyphen.

### Canonical URL redirect

The API canonicalizes fusion names, so a page reached through the legacy hyphen form now settles on the canonical URL. `getCanonicalFusionAlteration` compares the alteration that was queried against the one the annotation came back with, and the alteration and cancer type pages `history.replace` to the canonical page link when they differ.

This is deliberately limited to fusions. The API also normalizes protein changes (`Val600Glu` to `V600E`), which the pages render as-is by design, so the helper only redirects when the annotated name contains `::`. Ambiguous queries such as `NKX3-1-ABL1 Fusion` are rejected by the API rather than normalized, so there is nothing to redirect to and the page is left alone.

Reactions in both pages are now collected and disposed in `componentWillUnmount`. This matters for the redirect specifically: the annotation can resolve after the user has navigated away, and an undisposed reaction would pull them back to the alteration page.

### Other changes

- `FUSION_SEPARATOR` constant, with a note on why the hyphen form is ambiguous (partner symbols like `NKX3-1` and `HLA-A` contain one).
- Fusion example row in the search info icon overlay.
- Regenerated API clients. `SomaticVariantAnnotation.alterationValidationError` is replaced by an `errors: ValidationError[]` array, which adds the `AMBIGUOUS_FUSION_SEPARATOR` type; `DEFAULT_ANNOTATION` follows. The regen also picks up the unrelated `/utils/genomicIndicators` endpoint and `inheritanceMechanisms` filters.

### Test plan

- `FusionUtils.spec.ts` covers the helper: hyphen queries that get normalized, queries that are already canonical, normalized protein changes and categorical alterations that must be left alone, the ambiguous fusion case, and missing values.
- Manually: `/gene/ABL1/somatic/BCR-ABL1 Fusion` redirects to the `::` form with search and hash preserved; `/gene/BRAF/somatic/Val600Glu` does not redirect.
