### PR TITLE
Fix: Optimize Slack expand duplicate-user lookup performance

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/repository/UserMailsRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/UserMailsRepository.java
@@ -41,5 +41,11 @@ public interface UserMailsRepository extends JpaRepository<UserMails, Long> {
 
     List<UserMails> findUserMailByUserAndMailTypeIn(User user, List<MailType> mailTypes);
 
+    @Query(
+        value = "select distinct um.user_id from user_mails um where um.user_id in (:userIds) and um.mail_type in (:mailTypes)",
+        nativeQuery = true
+    )
+    List<Long> findUserIdsWithMailTypeIn(@Param("userIds") List<Long> userIds, @Param("mailTypes") List<String> mailTypes);
+
     void deleteAllByUser(User user);
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/UserRepository.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/UserRepository.java
@@ -2,6 +2,7 @@ package org.mskcc.cbio.oncokb.repository;
 
 import org.mskcc.cbio.oncokb.domain.User;
 import org.mskcc.cbio.oncokb.repository.projection.SendEmailUserOptionProjection;
+import org.mskcc.cbio.oncokb.repository.projection.PotentialDuplicateUserProjection;
 import org.mskcc.cbio.oncokb.repository.projection.UserWithDetailsProjection;
 
 import org.springframework.cache.annotation.Cacheable;
@@ -135,6 +136,30 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "where lower(user.login) in :candidates or lower(user.email) in :candidates"
     )
     List<UserWithDetailsProjection> findUsersWithDetailsByLoginOrEmailIn(@Param("candidates") java.util.List<String> candidates);
+
+    @Query(
+        value = "SELECT u.id AS id, " +
+            "u.first_name AS firstName, " +
+            "u.last_name AS lastName, " +
+            "u.email AS email, " +
+            "ud.company_name AS companyName, " +
+            "ud.city AS city, " +
+            "ud.country AS country " +
+            "FROM jhi_user u " +
+            "LEFT JOIN user_details ud ON ud.user_id = u.id " +
+            "WHERE u.id <> :userId " +
+            "AND u.login <> :anonymousLogin " +
+            "AND NOT EXISTS (" +
+            "  SELECT 1 FROM jhi_user_authority ua " +
+            "  WHERE ua.user_id = u.id AND ua.authority_name = :excludedAuthority" +
+            ")",
+        nativeQuery = true
+    )
+    List<PotentialDuplicateUserProjection> findPotentialDuplicateCandidates(
+        @Param("userId") Long userId,
+        @Param("anonymousLogin") String anonymousLogin,
+        @Param("excludedAuthority") String excludedAuthority
+    );
 
     @Query(
         value = "SELECT u.login AS login, u.email AS email, u.first_name AS firstName, u.last_name AS lastName, " +

--- a/src/main/java/org/mskcc/cbio/oncokb/repository/projection/PotentialDuplicateUserProjection.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/repository/projection/PotentialDuplicateUserProjection.java
@@ -1,0 +1,17 @@
+package org.mskcc.cbio.oncokb.repository.projection;
+
+public interface PotentialDuplicateUserProjection {
+    Long getId();
+
+    String getFirstName();
+
+    String getLastName();
+
+    String getEmail();
+
+    String getCompanyName();
+
+    String getCity();
+
+    String getCountry();
+}

--- a/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SlackService.java
@@ -29,6 +29,7 @@ import org.mskcc.cbio.oncokb.domain.Company;
 import org.mskcc.cbio.oncokb.domain.UserIdMessagePair;
 import org.mskcc.cbio.oncokb.domain.enumeration.*;
 import org.mskcc.cbio.oncokb.domain.enumeration.slack.*;
+import org.mskcc.cbio.oncokb.service.dto.PotentialDuplicateUserSummary;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.dto.UserMailsDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
@@ -664,20 +665,24 @@ public class SlackService {
             layoutBlocks.add(buildMarkdownBlock(":nerd_alert: *This user may be from Iran. OncoKB cannot be licensed to users in Iran.*", COUNTRY_WARNING));
         }
 
-        List<UserDTO> potentialDuplicateUsers = userService.getPotentialDuplicateAccountsByUser(userDTO);
+        List<PotentialDuplicateUserSummary> potentialDuplicateUsers = userService.getPotentialDuplicateAccountsByUser(userDTO);
         if (!potentialDuplicateUsers.isEmpty()) {
             StringBuilder sb = new StringBuilder(":warning: *This user may have already registered. A list of previously registered users:*");
-            for (UserDTO user : potentialDuplicateUsers) {
-                List<MailType> rejectionMailTypes = new ArrayList<>(Arrays.asList(MailType.REJECTION_US_SANCTION, MailType.REJECT_ALUMNI_ADDRESS, MailType.REJECTION));
-                List<UserMailsDTO> rejectionUserMails = userMailsService.findUserMailsByUserAndMailTypeIn(userMapper.userDTOToUser(user), rejectionMailTypes);
-
+            List<MailType> rejectionMailTypes = Arrays.asList(MailType.REJECTION_US_SANCTION, MailType.REJECT_ALUMNI_ADDRESS, MailType.REJECTION);
+            List<Long> potentialDuplicateUserIds = potentialDuplicateUsers
+                .stream()
+                .map(PotentialDuplicateUserSummary::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+            Set<Long> rejectedUserIds = userMailsService.findUserIdsWithMailTypeIn(potentialDuplicateUserIds, rejectionMailTypes);
+            for (PotentialDuplicateUserSummary user : potentialDuplicateUsers) {
                 sb.append("\n\u2022 ");
                 sb.append(StringUtil.getFullName(user.getFirstName(), user.getLastName()));
                 sb.append(", " + getEmailMarkdownWithUserPageLinkout(user.getEmail()));
                 sb.append(", " + user.getCompanyName());
                 sb.append(", " + user.getCity());
                 sb.append(", " + user.getCountry());
-                if (!rejectionUserMails.isEmpty()) {
+                if (rejectedUserIds.contains(user.getId())) {
                     sb.append(", *REJECTED*");
                 }
             }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserMailsService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserMailsService.java
@@ -20,9 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.mskcc.cbio.oncokb.config.cache.UserCacheResolver.ALL_USERS_CACHE;
@@ -131,6 +134,15 @@ public class UserMailsService {
         return userMailsRepository.findUserMailByUserAndMailTypeIn(user, mailTypes).stream()
             .map(userMailsMapper::toDto)
             .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Long> findUserIdsWithMailTypeIn(List<Long> userIds, List<MailType> mailTypes) {
+        if (userIds == null || userIds.isEmpty() || mailTypes == null || mailTypes.isEmpty()) {
+            return Collections.emptySet();
+        }
+        List<String> mailTypeNames = mailTypes.stream().map(MailType::name).collect(Collectors.toList());
+        return new HashSet<>(userMailsRepository.findUserIdsWithMailTypeIn(userIds, mailTypeNames));
     }
 
     /**

--- a/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/UserService.java
@@ -18,12 +18,14 @@ import org.mskcc.cbio.oncokb.repository.CompanyRepository;
 import org.mskcc.cbio.oncokb.repository.projection.SendEmailUserOptionProjection;
 import org.mskcc.cbio.oncokb.repository.UserDetailsRepository;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
+import org.mskcc.cbio.oncokb.repository.projection.PotentialDuplicateUserProjection;
 import org.mskcc.cbio.oncokb.repository.projection.UserWithDetailsProjection;
 import org.mskcc.cbio.oncokb.security.AuthoritiesConstants;
 import org.mskcc.cbio.oncokb.security.SecurityUtils;
 import org.mskcc.cbio.oncokb.security.uuid.TokenProvider;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.*;
 import org.mskcc.cbio.oncokb.service.dto.CompanyDTO;
+import org.mskcc.cbio.oncokb.service.dto.PotentialDuplicateUserSummary;
 import org.mskcc.cbio.oncokb.service.dto.SendEmailUserOptionDTO;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.mapper.UserMailsMapper;
@@ -985,21 +987,34 @@ public class UserService {
         return user.getAuthorities().stream().filter(userAuth -> userAuth.getName().equalsIgnoreCase(authority)).count() > 0;
     }
 
-    public List<UserDTO> getPotentialDuplicateAccountsByUser(UserDTO user) {
-        return searchAccountsForPotentialDuplicateUser(user, getAllManagedUsers());
+    public List<PotentialDuplicateUserSummary> getPotentialDuplicateAccountsByUser(UserDTO user) {
+        List<PotentialDuplicateUserProjection> candidates = userRepository.findPotentialDuplicateCandidates(
+            user.getId(),
+            Constants.ANONYMOUS_USER,
+            AuthoritiesConstants.ROLE_SERVICE_ACCOUNT
+        );
+        return searchAccountsForPotentialDuplicateUserCandidates(user, candidates);
     }
 
-    public List<UserDTO> searchAccountsForPotentialDuplicateUser(UserDTO user, List<UserDTO> allUsers) {
+    public List<PotentialDuplicateUserSummary> searchAccountsForPotentialDuplicateUserCandidates(UserDTO user, List<PotentialDuplicateUserProjection> candidates) {
         JaroWinklerSimilarity jw = new JaroWinklerSimilarity();
-        List<UserDTO> potentialDuplicateUsers = new ArrayList<>();
-        for (UserDTO potentialDuplicate : allUsers) {
-            if (user.getId().equals(potentialDuplicate.getId())) {
+        List<PotentialDuplicateUserSummary> potentialDuplicateUsers = new ArrayList<>();
+        for (PotentialDuplicateUserProjection potentialDuplicate : candidates) {
+            if (user.getId() != null && user.getId().equals(potentialDuplicate.getId())) {
                 continue;
             }
-
-            Double similarity = jw.apply(user.getFirstName(), potentialDuplicate.getFirstName()) * .3 + jw.apply(user.getLastName(), potentialDuplicate.getLastName()) * .7;
+            Double similarity = jw.apply(user.getFirstName(), potentialDuplicate.getFirstName()) * .3
+                + jw.apply(user.getLastName(), potentialDuplicate.getLastName()) * .7;
             if (similarity > .87) {
-                potentialDuplicateUsers.add(potentialDuplicate);
+                PotentialDuplicateUserSummary summary = new PotentialDuplicateUserSummary();
+                summary.setId(potentialDuplicate.getId());
+                summary.setFirstName(potentialDuplicate.getFirstName());
+                summary.setLastName(potentialDuplicate.getLastName());
+                summary.setEmail(potentialDuplicate.getEmail());
+                summary.setCompanyName(potentialDuplicate.getCompanyName());
+                summary.setCity(potentialDuplicate.getCity());
+                summary.setCountry(potentialDuplicate.getCountry());
+                potentialDuplicateUsers.add(summary);
             }
         }
         return potentialDuplicateUsers;

--- a/src/main/java/org/mskcc/cbio/oncokb/service/dto/PotentialDuplicateUserSummary.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/dto/PotentialDuplicateUserSummary.java
@@ -1,0 +1,67 @@
+package org.mskcc.cbio.oncokb.service.dto;
+
+public class PotentialDuplicateUserSummary {
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String companyName;
+    private String city;
+    private String country;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+}

--- a/src/test/java/org/mskcc/cbio/oncokb/service/SlackServiceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/SlackServiceIT.java
@@ -21,6 +21,7 @@ import org.mskcc.cbio.oncokb.domain.User;
 import org.mskcc.cbio.oncokb.domain.Company;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseStatus;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
+import org.mskcc.cbio.oncokb.service.dto.PotentialDuplicateUserSummary;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.ApiAccessRequest;
@@ -86,7 +87,7 @@ class SlackServiceIT {
         applicationProperties.setSlack(new SlackProperties());
         applicationProperties.getSlack().setUserRegistrationWebhook(USER_REGISTRATION_WEBHOOK);
 
-        doReturn(new ArrayList<UserDTO>()).when(userService).getPotentialDuplicateAccountsByUser(any(UserDTO.class));
+        doReturn(new ArrayList<PotentialDuplicateUserSummary>()).when(userService).getPotentialDuplicateAccountsByUser(any(UserDTO.class));
         doReturn(new ArrayList<>()).when(userMailsService).findUserMailsByUserAndMailTypeIn(any(User.class), anyList());
         slackService = new SlackService(applicationProperties, mailService, userService, userMailsService, userMapper, slack);
     }
@@ -255,9 +256,9 @@ class SlackServiceIT {
         user.setCountry("country");
         user.setLicenseType(LicenseType.COMMERCIAL);
 
-        List<UserDTO> duplicateUsers = new ArrayList<>();
+        List<PotentialDuplicateUserSummary> duplicateUsers = new ArrayList<>();
         for (int i = 0; i < 40; i++) {
-            UserDTO duplicateUser = new UserDTO();
+            PotentialDuplicateUserSummary duplicateUser = new PotentialDuplicateUserSummary();
             duplicateUser.setFirstName("VeryLongFirstName" + i);
             duplicateUser.setLastName("VeryLongLastName" + i);
             duplicateUser.setEmail("very.long.duplicate.user." + i + "@example.com");

--- a/src/test/java/org/mskcc/cbio/oncokb/service/UserServiceIT.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/UserServiceIT.java
@@ -10,12 +10,15 @@ import org.mskcc.cbio.oncokb.domain.enumeration.AccountRequestStatus;
 import org.mskcc.cbio.oncokb.domain.enumeration.BulkEmailAudience;
 import org.mskcc.cbio.oncokb.domain.enumeration.LicenseType;
 import org.mskcc.cbio.oncokb.repository.AuthorityRepository;
+import org.mskcc.cbio.oncokb.repository.projection.PotentialDuplicateUserProjection;
 import org.mskcc.cbio.oncokb.repository.UserDetailsRepository;
 import org.mskcc.cbio.oncokb.repository.UserRepository;
 import org.mskcc.cbio.oncokb.security.AuthoritiesConstants;
+import org.mskcc.cbio.oncokb.service.dto.PotentialDuplicateUserSummary;
 import org.mskcc.cbio.oncokb.service.dto.UserDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.AdditionalInfoDTO;
 import org.mskcc.cbio.oncokb.service.dto.useradditionalinfo.TrialAccount;
+import org.mskcc.cbio.oncokb.service.projection.PotentialDuplicateUserProjectionImpl;
 import org.mskcc.cbio.oncokb.service.mapper.UserMapper;
 
 import io.github.jhipster.security.RandomUtil;
@@ -49,6 +52,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.when;
 
@@ -466,7 +470,7 @@ public class UserServiceIT {
         user.setLastName(originalName.right);
         user.setId(id);
 
-        List<UserDTO> allUsers = new ArrayList<>();
+        List<PotentialDuplicateUserProjection> allUsers = new ArrayList<>();
 
         List<UserDTO> similarUsers = new ArrayList<>();
         for (Pair<String, String> similarName : similarNames) {
@@ -476,7 +480,15 @@ public class UserServiceIT {
             newUser.setId(++id);
             similarUsers.add(newUser);
 
-            allUsers.add(newUser);
+            allUsers.add(new PotentialDuplicateUserProjectionImpl(
+                newUser.getId(),
+                newUser.getFirstName(),
+                newUser.getLastName(),
+                null,
+                null,
+                null,
+                null
+            ));
         }
 
         for (Pair<String, String> dissimilarName : dissimilarNames) {
@@ -485,17 +497,40 @@ public class UserServiceIT {
             newUser.setLastName(dissimilarName.right);
             newUser.setId(++id);
 
-            allUsers.add(newUser);
+            allUsers.add(new PotentialDuplicateUserProjectionImpl(
+                newUser.getId(),
+                newUser.getFirstName(),
+                newUser.getLastName(),
+                null,
+                null,
+                null,
+                null
+            ));
         }
 
         UserDTO testSameIdUser = new UserDTO(); //need this to ensure comparison of IDs is done correctly, Longs are compared by reference
         testSameIdUser.setFirstName(user.getFirstName());
         testSameIdUser.setLastName(user.getLastName());
         testSameIdUser.setId(new Long(user.getId()));
-        allUsers.add(testSameIdUser);
+        allUsers.add(new PotentialDuplicateUserProjectionImpl(
+            testSameIdUser.getId(),
+            testSameIdUser.getFirstName(),
+            testSameIdUser.getLastName(),
+            null,
+            null,
+            null,
+            null
+        ));
 
-        List<UserDTO> duplicateUsers = userService.searchAccountsForPotentialDuplicateUser(user, allUsers);
-        assertThat(duplicateUsers).containsExactlyInAnyOrder(similarUsers.toArray(new UserDTO[similarUsers.size()]));
+        List<PotentialDuplicateUserSummary> duplicateUsers = userService.searchAccountsForPotentialDuplicateUserCandidates(user, allUsers);
+        assertThat(duplicateUsers)
+            .extracting(PotentialDuplicateUserSummary::getId, PotentialDuplicateUserSummary::getFirstName, PotentialDuplicateUserSummary::getLastName)
+            .containsExactlyInAnyOrderElementsOf(
+                similarUsers
+                    .stream()
+                    .map(similarUser -> tuple(similarUser.getId(), similarUser.getFirstName(), similarUser.getLastName()))
+                    .collect(Collectors.toList())
+            );
     }
 
     @Test

--- a/src/test/java/org/mskcc/cbio/oncokb/service/projection/PotentialDuplicateUserProjectionImpl.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/projection/PotentialDuplicateUserProjectionImpl.java
@@ -1,0 +1,66 @@
+package org.mskcc.cbio.oncokb.service.projection;
+
+import org.mskcc.cbio.oncokb.repository.projection.PotentialDuplicateUserProjection;
+
+public class PotentialDuplicateUserProjectionImpl implements PotentialDuplicateUserProjection {
+    private final Long id;
+    private final String firstName;
+    private final String lastName;
+    private final String email;
+    private final String companyName;
+    private final String city;
+    private final String country;
+
+    public PotentialDuplicateUserProjectionImpl(
+        Long id,
+        String firstName,
+        String lastName,
+        String email,
+        String companyName,
+        String city,
+        String country
+    ) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.companyName = companyName;
+        this.city = city;
+        this.country = country;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @Override
+    public String getLastName() {
+        return lastName;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    @Override
+    public String getCity() {
+        return city;
+    }
+
+    @Override
+    public String getCountry() {
+        return country;
+    }
+}


### PR DESCRIPTION
## Summary
Optimizes the Slack registration-request expand path by replacing duplicate-user N+1 lookups with batched and minimal-data queries, and refactoring duplicate result handling to a dedicated summary model.

## Problem
Expanding collapsed registration requests in Slack was slow, with performance degraded by repeated duplicate-user and rejection-mail checks.

## Root cause
The expand flow performed non-batched lookups and fetched broader user data than needed, causing avoidable query overhead in the duplicate-detection path.

## Fix approach
- Added native SQL duplicate-candidate retrieval in `UserRepository` with a projection that selects only required fields.
- Added batched native SQL lookup in `UserMailsRepository` to fetch user IDs that already received rejection emails.
- Added `UserMailsService` helper returning a `Set<Long>` for batched rejection status checks.
- Refactored Slack duplicate rendering to prefetch rejection states once and avoid per-user mail lookups.
- Introduced `PotentialDuplicateUserSummary` and updated `UserService` duplicate APIs to return this summary instead of reusing `UserDTO`.
- Updated `UserServiceIT` and added projection test helper for duplicate-candidate assertions.

## Testing (including reproduction coverage)
- `./mvnw -Denforcer.skip=true -DskipTests compile` ✅
- `./mvnw -Denforcer.skip=true -Dtest=UserServiceIT#assertThatDuplicateUsersAreCaught test` ✅ (run with Java 8)

## Risk / Rollout
- Low functional risk: behavior is focused on duplicate detection and Slack expand rendering paths.
- Main change is query strategy (batched/minimal projection) rather than user-facing business rules.

## Related issues
Fixes oncokb/oncokb-pipeline#1262