### PR TITLE
Feature: Label TERT genomic (g.) alterations as promoter mutations

### DIFF
--- a/src/main/webapp/app/pages/genePage/SomaticGermlineGenePage.tsx
+++ b/src/main/webapp/app/pages/genePage/SomaticGermlineGenePage.tsx
@@ -16,11 +16,13 @@ import { Else, If, Then } from 'react-if';
 import { Redirect, RouteComponentProps } from 'react-router';
 import { Button, Col, Container, Row } from 'react-bootstrap';
 import {
+  addPromoterMutationLabel,
   getCancerTypeNameFromOncoTreeType,
   getCancerTypesName,
   getFdaImplicationsFromTags,
   getImplicationsFromTags,
   getPageTitle,
+  isPromoterGenomicAlteration,
 } from 'app/shared/utils/Utils';
 import LoadingIndicator, {
   LoaderSize,
@@ -180,6 +182,15 @@ export default class SomaticGermlineGenePage extends React.Component<
       const excludedCancerTypeNames = variant.excludedCancerTypes.map(
         cancerType => getCancerTypeNameFromOncoTreeType(cancerType)
       );
+      // Same name the table has always rendered, only promoter alterations
+      // get the extra label. Keep the filterable/sortable name in sync with
+      // what the table renders.
+      const alterationName = isPromoterGenomicAlteration(
+        this.store.hugoSymbol,
+        variant.variant.alteration
+      )
+        ? addPromoterMutationLabel(variant.variant.name)
+        : variant.variant.name;
       const alterationView = variant.variant.consequence ? (
         <AlterationPageLink
           key={variant.variant.name}
@@ -194,7 +205,7 @@ export default class SomaticGermlineGenePage extends React.Component<
           germline={this.store.germline}
         />
       ) : (
-        <span>{variant.variant.name}</span>
+        <span>{alterationName}</span>
       );
       const cancerTypesName = getCancerTypesName(
         cancerTypeNames,
@@ -236,7 +247,7 @@ export default class SomaticGermlineGenePage extends React.Component<
         variant.drug.forEach(drug => {
           acc.push({
             level: variant.level,
-            alterations: variant.variant.name,
+            alterations: alterationName,
             alterationsView: alterationView,
             drugs: drug,
             cancerTypes: cancerTypesName,
@@ -252,7 +263,7 @@ export default class SomaticGermlineGenePage extends React.Component<
       } else {
         acc.push({
           level: variant.level,
-          alterations: variant.variant.name,
+          alterations: alterationName,
           alterationsView: alterationView,
           drugs: '',
           cancerTypes: cancerTypesName,

--- a/src/main/webapp/app/shared/utils/AlterationNameUtils.spec.ts
+++ b/src/main/webapp/app/shared/utils/AlterationNameUtils.spec.ts
@@ -1,0 +1,59 @@
+import { addPromoterMutationLabel, isPromoterGenomicAlteration } from './Utils';
+
+describe('isPromoterGenomicAlteration', () => {
+  it('is true for TERT genomic alterations', () => {
+    expect(isPromoterGenomicAlteration('TERT', 'g.1295228G>A')).toBeTruthy();
+    expect(isPromoterGenomicAlteration('tert', 'g.1295228G>A')).toBeTruthy();
+  });
+
+  it('is true for TERT genomic alterations with a reference sequence prefix', () => {
+    expect(isPromoterGenomicAlteration('TERT', '5:g.1295228G>A')).toBeTruthy();
+    expect(
+      isPromoterGenomicAlteration('TERT', '5:g.1295228_1295229delinsAA')
+    ).toBeTruthy();
+    expect(
+      isPromoterGenomicAlteration('TERT', 'NC_000005.9:g.1295228G>A')
+    ).toBeTruthy();
+  });
+
+  it('is false for non genomic TERT alterations', () => {
+    expect(isPromoterGenomicAlteration('TERT', 'C228T')).toBeFalsy();
+    expect(
+      isPromoterGenomicAlteration('TERT', 'Promoter Mutations')
+    ).toBeFalsy();
+  });
+
+  it('is false for other genes', () => {
+    expect(isPromoterGenomicAlteration('BRAF', 'g.140453136A>T')).toBeFalsy();
+    expect(isPromoterGenomicAlteration(undefined, 'g.1295113G>A')).toBeFalsy();
+  });
+});
+
+describe('addPromoterMutationLabel', () => {
+  it('appends the label to the alteration name', () => {
+    expect(addPromoterMutationLabel('g.1295113G>A')).toEqual(
+      'g.1295113G>A (Promoter mutation)'
+    );
+  });
+
+  it('appends the label to a name that already shows the alteration diff', () => {
+    expect(addPromoterMutationLabel('C228T (g.1295113G>A)')).toEqual(
+      'C228T (g.1295113G>A) (Promoter mutation)'
+    );
+  });
+
+  it('appends the label to the curated names as they come from the API', () => {
+    expect(addPromoterMutationLabel('5:g.1295228G>A {c.-124C>T}')).toEqual(
+      '5:g.1295228G>A {c.-124C>T} (Promoter mutation)'
+    );
+  });
+
+  it('does not label a name that already says promoter', () => {
+    expect(addPromoterMutationLabel('TERT Promoter Mutation')).toEqual(
+      'TERT Promoter Mutation'
+    );
+    expect(
+      addPromoterMutationLabel('TERT Promoter Mutation (g.1295113G>A)')
+    ).toEqual('TERT Promoter Mutation (g.1295113G>A)');
+  });
+});

--- a/src/main/webapp/app/shared/utils/UrlUtils.tsx
+++ b/src/main/webapp/app/shared/utils/UrlUtils.tsx
@@ -9,11 +9,13 @@ import {
   YOUTUBE_VIDEO_IDS,
 } from 'app/config/constants';
 import {
+  addPromoterMutationLabel,
   encodeSlash,
   getAlterationName,
   getCategoricalAlteration,
   getYouTubeLink,
   IAlteration,
+  isPromoterGenomicAlteration,
 } from 'app/shared/utils/Utils';
 import { Linkout } from 'app/shared/links/Linkout';
 import ExternalLinkIcon from 'app/shared/icons/ExternalLinkIcon';
@@ -155,7 +157,19 @@ export const AlterationPageLink: React.FunctionComponent<{
   onClick?: () => void;
   isTag?: boolean;
 }> = ({ germline = false, isTag = false, ...props }) => {
-  const alterationName = getAlterationName(props.alteration, true);
+  // Only the display text is gene aware; the page link below must keep using
+  // the raw alteration name.
+  const name = getAlterationName(props.alteration, true);
+  const alteration =
+    typeof props.alteration === 'string'
+      ? props.alteration
+      : props.alteration.alteration;
+  const alterationName = isPromoterGenomicAlteration(
+    props.hugoSymbol,
+    alteration
+  )
+    ? addPromoterMutationLabel(name)
+    : name;
   const pageLink = getAlterationPageLink({
     hugoSymbol: props.hugoSymbol,
     alteration: props.alteration,

--- a/src/main/webapp/app/shared/utils/Utils.tsx
+++ b/src/main/webapp/app/shared/utils/Utils.tsx
@@ -852,6 +852,45 @@ export function getAlterationName(
   }
 }
 
+/* ---------------------------------------------------------------------------
+ * TODO: delete this section once genomic (g.) alterations are curated with a
+ * name that says they are promoter mutations. Everything below only exists to
+ * label them on the fly, and is deliberately kept apart from getAlterationName
+ * so it can be removed in one piece.
+ * ------------------------------------------------------------------------ */
+
+// Genes where every genomic (HGVS g.) alteration is located in the promoter
+// region. These alterations are curated individually and their names carry no
+// indication that they are promoter mutations, so we label them for display.
+export const PROMOTER_ONLY_GENOMIC_ALTERATION_GENES = ['TERT'];
+export const PROMOTER_MUTATION_LABEL = 'Promoter mutation';
+
+// Genomic alterations are curated with a reference sequence prefix, e.g.
+// "5:g.1295228G>A", so allow an optional prefix before the "g." part.
+const GENOMIC_ALTERATION_REGEX = /^([^:\s]+:)?g\./i;
+
+export const isPromoterGenomicAlteration = (
+  hugoSymbol: string | undefined,
+  alteration: string
+): boolean => {
+  return (
+    !!hugoSymbol &&
+    PROMOTER_ONLY_GENOMIC_ALTERATION_GENES.includes(hugoSymbol.toUpperCase()) &&
+    GENOMIC_ALTERATION_REGEX.test(alteration.trim())
+  );
+};
+
+/**
+ * Appends the promoter mutation label to an already composed display name.
+ * Only call it for alterations isPromoterGenomicAlteration accepts, and only
+ * for display, never when building links or queries.
+ */
+export function addPromoterMutationLabel(displayName: string): string {
+  return displayName.toLowerCase().includes('promoter')
+    ? displayName
+    : `${displayName} (${PROMOTER_MUTATION_LABEL})`;
+}
+
 export const getGeneCoordinates = (ensemblGenes: EnsemblGene[]) => {
   return sortBy(ensemblGenes, ensemblGene => ensemblGene.referenceGenome)
     .map(

--- a/src/main/webapp/app/store/AnnotationStore.ts
+++ b/src/main/webapp/app/store/AnnotationStore.ts
@@ -39,9 +39,11 @@ import {
 } from 'app/shared/api/generated/OncoKbPrivateAPI';
 import { BarChartDatum } from 'app/components/barChart/BarChart';
 import {
+  addPromoterMutationLabel,
   getAlterationName,
   getCancerTypeNameFromOncoTreeType,
   isOncogenic,
+  isPromoterGenomicAlteration,
   shortenOncogenicity,
   shortenPathogenicity,
 } from 'app/shared/utils/Utils';
@@ -852,13 +854,20 @@ export class AnnotationStore {
 
   @computed
   get alterationNameWithDiff() {
-    return this.computeAlterationName(
+    const name = this.computeAlterationName(
       this.annotationType,
       this.alteration,
       this.alterationQuery,
       this.selectedAnnotationData,
       true
     );
+    // TODO: remove once genomic (g.) alterations are curated with a name that
+    // says they are promoter mutations. This is display only, alterationName
+    // above is what links and queries should keep using.
+    const alt = this.alteration?.alteration ?? this.alterationQuery;
+    return alt && isPromoterGenomicAlteration(this.hugoSymbol, alt)
+      ? addPromoterMutationLabel(name)
+      : name;
   }
 
   @computed


### PR DESCRIPTION
## Summary

Appends a "(Promoter mutation)" label to the display name of TERT alterations curated as HGVS genomic (`g.`) variants, e.g. `5:g.1295228G>A {c.-124C>T}` is shown as `5:g.1295228G>A {c.-124C>T} (Promoter mutation)`.

## Problem or opportunity

Every TERT genomic (`g.`) alteration is located in the promoter region, but these alterations are curated individually and their names carry no indication that they are promoter mutations. Users viewing them on the gene, alteration, and annotation pages cannot tell they are promoter variants.

## Implementation approach

- Added `isPromoterGenomicAlteration` and `addPromoterMutationLabel` to `Utils.tsx`, driven by `PROMOTER_ONLY_GENOMIC_ALTERATION_GENES = ['TERT']`. Genomic alterations are matched with an optional reference sequence prefix (`5:g.`, `NC_000005.9:g.`). Names that already mention "promoter" are left unchanged.
- Applied the label for display only in:
  - `AlterationPageLink` (`UrlUtils.tsx`)
  - `AnnotationStore.alterationNameWithDiff`
  - The therapeutic table on `SomaticGermlineGenePage`, where the plain-text alteration name used for filtering/sorting is kept in sync with the rendered name
- Page links and queries continue to use the raw alteration name.
- The helpers live in a self-contained TODO block so they can be removed in one piece once genomic alterations are curated with names that indicate they are promoter mutations.

## Testing

- Added `AlterationNameUtils.spec.ts` covering `isPromoterGenomicAlteration` and `addPromoterMutationLabel`.
- Tests to be run by the author.

## Risk / Rollout

- Display-only change scoped to TERT genomic alterations; links and API queries are unaffected.

## Related issues

Refs https://github.com/oncokb/oncokb-pipeline/issues/1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
