### PR TITLE
Fix: keep mini-nav underline synced with hash/scroll and highlight clicked section header

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,5 +1,7 @@
 name: Application CI
-on: [push, pull_request]
+on:
+    pull_request:
+        branches: [master]
 jobs:
     applications:
         name: oncokb test suite
@@ -28,7 +30,21 @@ jobs:
               run: |
                 chmod +x mvnw
                 ./mvnw -ntp clean verify -P-webpack
-#            - name: Run frontend test
-#              run: yarn run test-ci
             - name: Package application
               run: ./mvnw -ntp package -Pprod -DskipTests
+
+    frontend-tests:
+        name: frontend test suite
+        runs-on: ubuntu-latest
+        timeout-minutes: 40
+        env:
+            NODE_VERSION: 12.16.1
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 12.16.1
+            - name: Install node.js packages
+              run: yarn install
+            - name: Run frontend test
+              run: yarn run test -- --ci

--- a/.github/workflows/screenshot-test.yml
+++ b/.github/workflows/screenshot-test.yml
@@ -1,6 +1,8 @@
 name: Screenshot Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [master]
 
 jobs:
 

--- a/jest.conf.js
+++ b/jest.conf.js
@@ -13,8 +13,19 @@ module.exports = {
   coveragePathIgnorePatterns: ['<rootDir>/src/test/javascript/'],
   moduleNameMapper: mapTypescriptAliasToJestAlias({
     '\\.(css|scss)$': 'identity-obj-proxy',
+    '^react-helmet-async$':
+      '<rootDir>/src/main/webapp/app/test/reactHelmetAsyncMock.tsx',
   }),
-  reporters: ['default', ['jest-junit', { outputDirectory: './target/test-results/', outputName: 'TESTS-results-jest.xml' }]],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: './target/test-results/',
+        outputName: 'TESTS-results-jest.xml',
+      },
+    ],
+  ],
   testResultsProcessor: 'jest-sonar-reporter',
   testPathIgnorePatterns: ['<rootDir>/node_modules/'],
   setupFiles: [],

--- a/src/main/webapp/app/shared/nav/StickyMiniNavBar.module.scss
+++ b/src/main/webapp/app/shared/nav/StickyMiniNavBar.module.scss
@@ -51,6 +51,19 @@ $sticky-border: #e3e5ec;
   border-bottom-color: $primary;
 }
 
+@keyframes miniNavTargetFlash {
+  0% {
+    background-color: rgba($primary, 0.26);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+[mini-nav-bar-header][data-mini-nav-highlight] {
+  animation: miniNavTargetFlash 2.5s ease-out forwards;
+}
+
 @media (min-width: 550px) {
   .nav {
     flex-direction: row;

--- a/src/main/webapp/app/shared/nav/StickyMiniNavBar.tsx
+++ b/src/main/webapp/app/shared/nav/StickyMiniNavBar.tsx
@@ -1,5 +1,6 @@
 import React, {
   useEffect,
+  MouseEvent,
   useRef,
   useState,
   createContext,
@@ -17,18 +18,24 @@ function getNavBarSectionElements() {
   return document.querySelectorAll('[mini-nav-bar-header]');
 }
 
+function getHashElement(hash: string) {
+  if (!hash) {
+    return null;
+  }
+  try {
+    return document.querySelector(hash);
+  } catch {
+    return null;
+  }
+}
+
 function useScrollToHash({ stickyHeight }: { stickyHeight: number }) {
   const location = useLocation();
 
   useEffect(() => {
     const hash = location.hash;
     if (hash) {
-      let element: Element | null;
-      try {
-        element = document.querySelector(hash);
-      } catch {
-        element = null;
-      }
+      const element = getHashElement(hash);
       if (element) {
         const targetPosition =
           element.getBoundingClientRect().top + window.scrollY;
@@ -86,6 +93,9 @@ export default function StickyMiniNavBar({
 }: IStickyMiniNavBar) {
   const [headerHeight, setHeaderHeight] = useState(0);
   const [isSticky, setIsSticky] = useState(false);
+  const [hasScrollSinceHashChange, setHasScrollSinceHashChange] = useState(
+    false
+  );
   const [sections, setSections] = useState<
     { id: string; label: string | null; comingSoon: boolean }[]
   >([]);
@@ -94,7 +104,10 @@ export default function StickyMiniNavBar({
   >({});
   const { counter } = useContext(StickyMiniNavBarContext);
   const stickyDivRef = useRef<HTMLDivElement | null>(null);
-  useScrollToHash({
+  const autoScrollHashRef = useRef<string | undefined>(undefined);
+  const autoScrollExpiresAtRef = useRef(0);
+  const highlightTimeoutRef = useRef<number | undefined>(undefined);
+  const hash = useScrollToHash({
     stickyHeight:
       headerHeight +
       (stickyDivRef.current?.getBoundingClientRect().height ?? 0),
@@ -174,6 +187,91 @@ export default function StickyMiniNavBar({
   }, []);
 
   useEffect(() => {
+    setHasScrollSinceHashChange(false);
+    if (hash) {
+      autoScrollHashRef.current = hash;
+      autoScrollExpiresAtRef.current = Date.now() + 2000;
+    } else {
+      autoScrollHashRef.current = undefined;
+      autoScrollExpiresAtRef.current = 0;
+    }
+  }, [hash]);
+
+  const scrollToSection = useCallback(
+    (sectionId: string) => {
+      const sectionHash = `#${sectionId}`;
+      const element = getHashElement(sectionHash);
+      if (!element) {
+        return;
+      }
+
+      const stickyHeight =
+        headerHeight +
+        (stickyDivRef.current?.getBoundingClientRect().height ?? 0);
+      const targetPosition =
+        element.getBoundingClientRect().top + window.scrollY;
+      window.scrollTo({
+        behavior: 'smooth',
+        top: targetPosition - stickyHeight,
+      });
+    },
+    [headerHeight]
+  );
+
+  const onClickSection = useCallback(
+    (event: MouseEvent, sectionId: string) => {
+      const sectionElement = document.getElementById(sectionId);
+      if (sectionElement) {
+        sectionElement.removeAttribute('data-mini-nav-highlight');
+        // Force reflow so repeated clicks retrigger the animation.
+        void sectionElement.offsetWidth;
+        sectionElement.setAttribute('data-mini-nav-highlight', '');
+      }
+      if (highlightTimeoutRef.current !== undefined) {
+        window.clearTimeout(highlightTimeoutRef.current);
+      }
+      highlightTimeoutRef.current = window.setTimeout(() => {
+        sectionElement?.removeAttribute('data-mini-nav-highlight');
+      }, 2500);
+
+      setHasScrollSinceHashChange(false);
+      autoScrollHashRef.current = `#${sectionId}`;
+      autoScrollExpiresAtRef.current = Date.now() + 2000;
+
+      if (hash === `#${sectionId}`) {
+        event.preventDefault();
+        scrollToSection(sectionId);
+      }
+    },
+    [hash, scrollToSection]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimeoutRef.current !== undefined) {
+        window.clearTimeout(highlightTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const cancelAutoScroll = () => {
+      autoScrollHashRef.current = undefined;
+      autoScrollExpiresAtRef.current = 0;
+    };
+
+    window.addEventListener('wheel', cancelAutoScroll, { passive: true });
+    window.addEventListener('touchstart', cancelAutoScroll, { passive: true });
+    window.addEventListener('keydown', cancelAutoScroll);
+
+    return () => {
+      window.removeEventListener('wheel', cancelAutoScroll);
+      window.removeEventListener('touchstart', cancelAutoScroll);
+      window.removeEventListener('keydown', cancelAutoScroll);
+    };
+  }, []);
+
+  useEffect(() => {
     const miniNavElement = stickyDivRef.current;
     const headerElement = getHeader();
     if (!miniNavElement || !headerElement) {
@@ -185,12 +283,37 @@ export default function StickyMiniNavBar({
       if (!ticking) {
         requestAnimationFrame(() => {
           const miniNavTop = miniNavElement.getBoundingClientRect().top;
+          const stickyHeight =
+            headerHeight +
+            (stickyDivRef.current?.getBoundingClientRect().height ?? 0);
           const translateY = miniNavTop - headerHeight;
           headerElement.style.transform = `translateY(${Math.min(
             translateY,
             0
           )}px)`;
           setIsSticky(miniNavTop === 0);
+          let isAutoScroll =
+            !!autoScrollHashRef.current &&
+            autoScrollExpiresAtRef.current > Date.now();
+
+          if (isAutoScroll && autoScrollHashRef.current) {
+            const targetElement = getHashElement(autoScrollHashRef.current);
+            if (targetElement) {
+              const targetY =
+                targetElement.getBoundingClientRect().top +
+                window.scrollY -
+                stickyHeight;
+              if (Math.abs(window.scrollY - targetY) <= 2) {
+                autoScrollHashRef.current = undefined;
+                autoScrollExpiresAtRef.current = 0;
+                isAutoScroll = false;
+              }
+            }
+          }
+
+          if (!isAutoScroll && !hasScrollSinceHashChange) {
+            setHasScrollSinceHashChange(true);
+          }
           ticking = false;
         });
       }
@@ -202,26 +325,36 @@ export default function StickyMiniNavBar({
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [headerHeight]);
+  }, [headerHeight, hasScrollSinceHashChange]);
 
-  let currentSectionId: string | undefined = undefined;
+  const hashSectionId = decodeURIComponent(hash).replace(/^#/, '');
+  const hasMatchedHashSection = sections.some(
+    section => section.id === hashSectionId
+  );
 
-  // If a section header is visible then the header at the top of the page wins
-  for (const section of sections) {
-    const passedInfo = passedElements[section.id] ?? {};
-    if (passedInfo.isInView) {
-      currentSectionId = section.id;
-      break;
-    }
-  }
+  let currentSectionId: string | undefined =
+    !hasScrollSinceHashChange && hasMatchedHashSection && hashSectionId
+      ? hashSectionId
+      : undefined;
 
-  // If no section header is in view then pick the last section header
-  // that was scrolled passed
   if (currentSectionId === undefined) {
+    // If a section header is visible then the header at the top of the page wins
     for (const section of sections) {
       const passedInfo = passedElements[section.id] ?? {};
-      if (passedInfo.isPassed) {
+      if (passedInfo.isInView) {
         currentSectionId = section.id;
+        break;
+      }
+    }
+
+    // If no section header is in view then pick the last section header
+    // that was scrolled passed
+    if (currentSectionId === undefined) {
+      for (const section of sections) {
+        const passedInfo = passedElements[section.id] ?? {};
+        if (passedInfo.isPassed) {
+          currentSectionId = section.id;
+        }
       }
     }
   }
@@ -275,6 +408,7 @@ export default function StickyMiniNavBar({
                       style={comingSoon ? { pointerEvents: 'none' } : undefined}
                       key={id}
                       to={`#${id}`}
+                      onClick={event => onClickSection(event, id)}
                       className={classNames(
                         styles.stickySection,
                         isInSection ? styles.stickySectionSelected : ''

--- a/src/main/webapp/app/test/reactHelmetAsyncMock.tsx
+++ b/src/main/webapp/app/test/reactHelmetAsyncMock.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const Helmet: React.FunctionComponent<{
+  children?: React.ReactNode;
+}> = ({ children }) => <>{children}</>;
+
+export const HelmetProvider: React.FunctionComponent<{
+  children?: React.ReactNode;
+}> = ({ children }) => <>{children}</>;


### PR DESCRIPTION
## Summary
This change keeps the sticky mini-nav underline in sync with hash navigation and scroll state, and adds a temporary visual highlight on the selected target header element.

## Problem
On variant pages, the mini-nav underline for implications sections could drift from the section a user expected after tab clicks and smooth scrolling, especially when re-clicking the same hash target.

## Root cause
Active-section state was split between hash-driven and intersection-driven behavior without consistent transitions for smooth scrolling and same-hash re-clicks.

## Fix approach
- Use hash as the initial source of truth, then switch to intersection-based tracking after non-auto scroll events.
- Distinguish auto-scroll from user scroll to avoid premature active-state switching.
- Handle same-hash link clicks by re-triggering smooth scroll and active-state refresh.
- Add a transient background highlight on the destination header element to provide immediate visual feedback.

## Testing (including reproduction coverage)
- `yarn run lint -- src/main/webapp/app/shared/nav/StickyMiniNavBar.tsx` 
  - Result: pass
- Manual verification scenarios to run:
  - Short page case: https://www.oncokb.org/gene/BRAF/somatic/Oncogenic%20Mutations/Erdheim-Chester%20Disease
  - Long page case: https://www.oncokb.org/gene/BRAF/somatic/V600E/All%20Solid%20Tumors#treatment-implications-of-this-biomarker

## Risk / Rollout
Low risk. Frontend-only behavior/CSS update in sticky mini-nav and section-header highlighting; no backend or data model changes.

## Related issues
Fixes oncokb/oncokb-pipeline#1264


https://github.com/user-attachments/assets/d3a5ecd9-c16f-47d9-96d1-bd3de6387d31

